### PR TITLE
Capture and visualise EEFRT trial responses in the mobile apps [CON-2555]

### DIFF
--- a/EEFRT Demo Android/app/build.gradle.kts
+++ b/EEFRT Demo Android/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -52,6 +53,10 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.webkit)
     implementation(libs.kotinx.serialization.json)
+    implementation(libs.androidx.room.common)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+    implementation(libs.gson)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
@@ -1,6 +1,9 @@
 package ai.a2i2.conductor.effrtdemoandroid
 
+import ai.a2i2.conductor.effrtdemoandroid.persistence.DatabaseProvider
 import ai.a2i2.conductor.effrtdemoandroid.ui.EefrtScreen
+import ai.a2i2.conductor.effrtdemoandroid.ui.EventLogsView
+import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtScreenViewModel
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -11,9 +14,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import ai.a2i2.conductor.effrtdemoandroid.ui.theme.EFFRTDemoAndroidTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.Button
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
@@ -24,35 +29,59 @@ import androidx.navigation.compose.rememberNavController
 enum class NavigationScreens(val route: String) {
     HOME("home"),
     EFFRT("eefrt"),
+    EVENTS("events"),
 }
 
 class MainActivity : ComponentActivity() {
+    private val appDatabase by lazy {
+        DatabaseProvider.provideAppDatabase(application)
+    }
+
+    private val eefrtScreenViewModel: EefrtScreenViewModel by lazy {
+        EefrtScreenViewModel(
+            appDatabase
+        )
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             EFFRTDemoAndroidTheme {
-                NavigationController()
+                NavigationController(eefrtScreenViewModel)
             }
         }
     }
 }
 
 @Composable
-fun NavigationController() {
+fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
     val navController = rememberNavController()
 
     NavHost(navController = navController, startDestination = NavigationScreens.HOME.route) {
         composable(NavigationScreens.HOME.route) {
             HomeScreen(
-                onClickButton = {
+                onStartTaskPressed = {
                     navController.navigate(NavigationScreens.EFFRT.route)
+                },
+                onViewEventLogsPressed = {
+                    navController.navigate(NavigationScreens.EVENTS.route)
                 }
             )
         }
 
         composable(NavigationScreens.EFFRT.route) {
             EefrtScreen(
+                eefrtViewModel = eefrtScreenViewModel,
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        composable(NavigationScreens.EVENTS.route) {
+            EventLogsView(
+                eefrtScreenViewModel = eefrtScreenViewModel,
                 onBack = {
                     navController.popBackStack()
                 }
@@ -62,13 +91,30 @@ fun NavigationController() {
 }
 
 @Composable
-fun HomeScreen(onClickButton: () -> Unit) {
+fun HomeScreen(
+    onStartTaskPressed: () -> Unit,
+    onViewEventLogsPressed: () -> Unit
+) {
     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-        AppButton(
-            name = "Begin EEFRT Task",
-            modifier = Modifier.padding(innerPadding),
-            onClick = onClickButton
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            AppButton(
+                name = "Begin EEFRT Task",
+                modifier = Modifier.padding(innerPadding),
+                onClick = onStartTaskPressed
+            )
+
+            Spacer(modifier = Modifier.padding(vertical = 20.0.dp))
+
+            AppButton(
+                name = "View Event Logs",
+                modifier = Modifier.padding(innerPadding),
+                onClick = onViewEventLogsPressed
+            )
+        }
     }
 }
 
@@ -76,7 +122,6 @@ fun HomeScreen(onClickButton: () -> Unit) {
 fun AppButton(name: String, modifier: Modifier = Modifier, onClick: () -> Unit) {
     Box(
         modifier = modifier
-            .fillMaxSize()
             .padding(16.dp)
     ) {
         Button(
@@ -86,13 +131,5 @@ fun AppButton(name: String, modifier: Modifier = Modifier, onClick: () -> Unit) 
         ) {
             Text(name)
         }
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun HomePreview() {
-    EFFRTDemoAndroidTheme {
-        NavigationController()
     }
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
@@ -3,6 +3,7 @@ package ai.a2i2.conductor.effrtdemoandroid
 import ai.a2i2.conductor.effrtdemoandroid.persistence.DatabaseProvider
 import ai.a2i2.conductor.effrtdemoandroid.ui.EefrtScreen
 import ai.a2i2.conductor.effrtdemoandroid.ui.EventLogsView
+import ai.a2i2.conductor.effrtdemoandroid.ui.EefrtTrialDetailView
 import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtScreenViewModel
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -30,6 +31,8 @@ enum class NavigationScreens(val route: String) {
     HOME("home"),
     EFFRT("eefrt"),
     EVENTS("events"),
+    PRACTICE_TRIAL_DETAILS("practice_trial_details"),
+    ACTUAL_TRIAL_DETAILS("actual_trial_details"),
 }
 
 class MainActivity : ComponentActivity() {
@@ -82,6 +85,34 @@ fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
         composable(NavigationScreens.EVENTS.route) {
             EventLogsView(
                 eefrtScreenViewModel = eefrtScreenViewModel,
+                practiceTaskItemPressed = { index ->
+                    navController.navigate("${NavigationScreens.PRACTICE_TRIAL_DETAILS}/${index}")
+                },
+                actualTaskItemPressed = { index ->
+                    navController.navigate("${NavigationScreens.ACTUAL_TRIAL_DETAILS}/${index}")
+                },
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        composable("${NavigationScreens.PRACTICE_TRIAL_DETAILS.route}/{index}") { navBackStackEntry ->
+            val routeIndex = navBackStackEntry.arguments?.getString("index")?.toInt() ?: 0
+            val practiceTrialItem = eefrtScreenViewModel.getPracticeTaskAttempts().value[routeIndex]
+            EefrtTrialDetailView(
+                eefrtTaskAttempt = practiceTrialItem,
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        composable("${NavigationScreens.ACTUAL_TRIAL_DETAILS.route}/{index}") { navBackStackEntry ->
+            val routeIndex = navBackStackEntry.arguments?.getString("index")?.toInt() ?: 0
+            val trialItem = eefrtScreenViewModel.getActualTaskAttempts().value[routeIndex]
+            EefrtTrialDetailView(
+                eefrtTaskAttempt = trialItem,
                 onBack = {
                     navController.popBackStack()
                 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/AppDatabase.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/AppDatabase.kt
@@ -1,0 +1,16 @@
+package ai.a2i2.conductor.effrtdemoandroid.persistence
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(
+    entities = [PracticeTaskAttempt::class, TaskAttempt::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(Converters::class)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun practiceTaskAttemptDao(): PracticeTaskAttemptDao
+    abstract fun taskAttemptDao(): TaskAttemptDto
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/Converters.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/Converters.kt
@@ -1,0 +1,35 @@
+package ai.a2i2.conductor.effrtdemoandroid.persistence
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import java.util.Date
+import kotlin.reflect.javaType
+import kotlin.reflect.typeOf
+
+class Converters {
+    companion object {
+        val gson = Gson()
+    }
+
+    @TypeConverter
+    fun dateToString(date: Date): String {
+        return gson.toJson(date)
+    }
+
+    @TypeConverter
+    @OptIn(ExperimentalStdlibApi::class)
+    fun stringToDate(data: String): Date {
+        return gson.fromJson(data, typeOf<Date>().javaType)
+    }
+
+    @TypeConverter
+    fun intListToString(list: List<Int>): String {
+        return gson.toJson(list)
+    }
+
+    @TypeConverter
+    @OptIn(ExperimentalStdlibApi::class)
+    fun stringToIntList(data: String): List<Int> {
+        return gson.fromJson(data, typeOf<List<Int>>().javaType)
+    }
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/DatabaseProvider.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/DatabaseProvider.kt
@@ -1,0 +1,14 @@
+package ai.a2i2.conductor.effrtdemoandroid.persistence
+
+import android.content.Context
+import androidx.room.Room
+
+object DatabaseProvider {
+    fun provideAppDatabase(context: Context): AppDatabase {
+        return Room.databaseBuilder(
+            context.applicationContext,
+            AppDatabase::class.java,
+            name = "app_database"
+        ).build()
+    }
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
@@ -1,0 +1,36 @@
+package ai.a2i2.conductor.effrtdemoandroid.persistence
+
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import java.util.Date
+
+@Entity(tableName = "practice_trial_events")
+data class PracticeTaskAttempt(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "created_at") var createdAt: Date?,
+    @ColumnInfo(name = "prac_trial_no") val pracTrialNo: Int,
+    @ColumnInfo(name = "trial_reward") val trialReward: Int,
+    @ColumnInfo(name = "trial_effort") val trialEffort: Int,
+    @ColumnInfo(name = "press_count") val pressCount: Int,
+    @ColumnInfo(name = "press_times") val pressTimes: List<Int>,
+    @ColumnInfo(name = "trial_success") val trialSuccess: Int,
+    @ColumnInfo(name = "gems_running_total") val gemsRunningTotal: Int,
+    @ColumnInfo(name = "max_press_count") val maxPressCount: Int,
+)
+
+@Dao
+interface PracticeTaskAttemptDao {
+    @Insert
+    suspend fun insert(practiceTaskAttempt: PracticeTaskAttempt)
+
+    @Delete
+    suspend fun delete(practiceTaskAttempt: PracticeTaskAttempt)
+
+    @Query("SELECT * FROM practice_trial_events ORDER BY created_at DESC")
+    suspend fun getAllPracticeTrialEvents(): List<PracticeTaskAttempt>
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
@@ -1,5 +1,6 @@
 package ai.a2i2.conductor.effrtdemoandroid.persistence
 
+import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtTaskAttempt
 import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Delete
@@ -21,7 +22,7 @@ data class PracticeTaskAttempt(
     @ColumnInfo(name = "trial_success") val trialSuccess: Int,
     @ColumnInfo(name = "gems_running_total") val gemsRunningTotal: Int,
     @ColumnInfo(name = "max_press_count") val maxPressCount: Int,
-)
+): EefrtTaskAttempt
 
 @Dao
 interface PracticeTaskAttemptDao {

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/TaskAttemptDto.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/TaskAttemptDto.kt
@@ -1,0 +1,46 @@
+package ai.a2i2.conductor.effrtdemoandroid.persistence
+
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import java.util.Date
+
+@Entity(tableName = "trial_attempt_events")
+data class TaskAttempt(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    @ColumnInfo(name = "created_at") var createdAt: Date?,
+    @ColumnInfo(name = "trial_no") val trialNo: Int,
+    @ColumnInfo(name = "trial_start_time") val trialStartTime: Int,
+    @ColumnInfo(name = "trial_reward_1") val trialReward1: Int,
+    @ColumnInfo(name = "trial_effort_1") val trialEffort1: Int,
+    @ColumnInfo(name = "trial_effort_prop_max_1") val trialEffortPropMax1: Double,
+    @ColumnInfo(name = "trial_reward_2") val trialReward2: Int,
+    @ColumnInfo(name = "trial_effort_2") val trialEffort2: Int,
+    @ColumnInfo(name = "trial_effort_prop_max_2") val trialEffortPropMax2: Double,
+    @ColumnInfo(name = "choice") val choice: String,
+    @ColumnInfo(name = "choice_rt") val choiceRT: Int,
+    @ColumnInfo(name = "press_count") val pressCount: Int,
+    @ColumnInfo(name = "press_times") val pressTimes: List<Int>,
+    @ColumnInfo(name = "trial_success") val trialSuccess: Int,
+    @ColumnInfo(name = "coins_running_total") val coinsRunningTotal: Int,
+    @ColumnInfo(name = "trial_end_time") val trialEndTime: Int,
+    @ColumnInfo(name = "effort_time_limit") val effortTimeLimit: Int,
+    @ColumnInfo(name = "recalibration") val recalibration: Int,
+    @ColumnInfo(name = "threshold_max") val thresholdMax: Int,
+)
+
+@Dao
+interface TaskAttemptDto {
+    @Insert
+    suspend fun insert(taskAttempt: TaskAttempt)
+
+    @Delete
+    suspend fun delete(taskAttempt: TaskAttempt)
+
+    @Query("SELECT * FROM trial_attempt_events ORDER BY created_at DESC")
+    suspend fun getAllTrialEvents(): List<TaskAttempt>
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/TaskAttemptDto.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/TaskAttemptDto.kt
@@ -1,5 +1,6 @@
 package ai.a2i2.conductor.effrtdemoandroid.persistence
 
+import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtTaskAttempt
 import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Delete
@@ -31,7 +32,7 @@ data class TaskAttempt(
     @ColumnInfo(name = "effort_time_limit") val effortTimeLimit: Int,
     @ColumnInfo(name = "recalibration") val recalibration: Int,
     @ColumnInfo(name = "threshold_max") val thresholdMax: Int,
-)
+): EefrtTaskAttempt
 
 @Dao
 interface TaskAttemptDto {

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtTrialDetailView.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtTrialDetailView.kt
@@ -1,0 +1,77 @@
+package ai.a2i2.conductor.effrtdemoandroid.ui
+
+import ai.a2i2.conductor.effrtdemoandroid.R
+import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtTaskAttempt
+import android.os.Handler
+import android.os.Looper
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EefrtTrialDetailView(
+    eefrtTaskAttempt: EefrtTaskAttempt,
+    onBack: () -> Unit
+) {
+    val scrollViewState = rememberScrollState()
+
+    fun formatPracticeTrialString(): String {
+        var practiceTrialString = eefrtTaskAttempt.toString()
+        practiceTrialString = practiceTrialString
+            .replace("(", "(\n ")
+            .replace(",", "\n")
+            .replace(")", "\n)")
+
+        return practiceTrialString
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = {
+                            dismiss(onBack)
+                        }
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.arrow_left),
+                            contentDescription = "Back",
+                        )
+                    }
+                }
+            )
+        },
+        content = { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .verticalScroll(scrollViewState)
+                    .padding(paddingValues)
+                    .padding(vertical = 16f.dp)
+            ) {
+                Text(
+                    text = formatPracticeTrialString(),
+                    modifier = Modifier
+                        .padding(horizontal = 16f.dp)
+                )
+            }
+        }
+    )
+}
+
+private fun dismiss(onBack: () -> Unit) {
+    Handler(Looper.getMainLooper()).post { onBack() }
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EventLogsView.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EventLogsView.kt
@@ -5,12 +5,11 @@ import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtScreenViewModel
 import android.annotation.SuppressLint
 import android.os.Handler
 import android.os.Looper
-import android.widget.ScrollView
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -29,8 +28,11 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun EventLogsView(
     eefrtScreenViewModel: EefrtScreenViewModel,
-    onBack: () -> Unit
-) {
+    practiceTaskItemPressed: (Int) -> Unit,
+    actualTaskItemPressed: (Int) -> Unit,
+    onBack: () -> Unit,
+
+    ) {
     val practiceTaskAttempts = remember { eefrtScreenViewModel.getPracticeTaskAttempts() }
     val actualTaskAttempts = remember { eefrtScreenViewModel.getActualTaskAttempts() }
     val scrollState = rememberScrollState()
@@ -61,13 +63,17 @@ fun EventLogsView(
             ) {
                 Text(
                     "Practice Attempts",
-                    modifier = Modifier.padding(8f.dp)
+                    modifier = Modifier.padding(16.dp)
                 )
 
-                for (practiceAttemptData in practiceTaskAttempts.value) {
+                practiceTaskAttempts.value.forEachIndexed { index, practiceTaskAttempt ->
                     Text(
-                        text = practiceAttemptData.createdAt.toString(),
-                        modifier = Modifier.padding(8f.dp)
+                        text = practiceTaskAttempt.createdAt.toString(),
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .clickable {
+                                practiceTaskItemPressed(index)
+                            }
                     )
                 }
 
@@ -75,16 +81,19 @@ fun EventLogsView(
 
                 Text(
                     "Actual Attempts",
-                    modifier = Modifier.padding(8f.dp)
+                    modifier = Modifier.padding(16.dp)
                 )
 
-                for (attemptData in actualTaskAttempts.value) {
+                actualTaskAttempts.value.forEachIndexed { index, taskAttempt ->
                     Text(
-                        text = attemptData.createdAt.toString(),
-                        modifier = Modifier.padding(8f.dp)
+                        text = taskAttempt.createdAt.toString(),
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .clickable {
+                                actualTaskItemPressed(index)
+                            }
                     )
                 }
-
             }
         }
     )

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EventLogsView.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EventLogsView.kt
@@ -6,12 +6,17 @@ import android.annotation.SuppressLint
 import android.os.Handler
 import android.os.Looper
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -20,6 +25,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 
@@ -67,14 +73,31 @@ fun EventLogsView(
                 )
 
                 practiceTaskAttempts.value.forEachIndexed { index, practiceTaskAttempt ->
-                    Text(
-                        text = practiceTaskAttempt.createdAt.toString(),
-                        modifier = Modifier
-                            .padding(16.dp)
-                            .clickable {
-                                practiceTaskItemPressed(index)
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = practiceTaskAttempt.createdAt.toString(),
+                            modifier = Modifier
+                                .padding(16.dp)
+                                .clickable {
+                                    practiceTaskItemPressed(index)
+                                }
+                        )
+
+                        Spacer(modifier = Modifier.weight(1f))
+
+                        IconButton(
+                            onClick = {
+                                eefrtScreenViewModel.deletePracticeTaskAttempt(practiceTaskAttempt)
                             }
-                    )
+                        ) {
+                            Image(
+                                imageVector = Icons.Outlined.Delete,
+                                contentDescription = "Delete",
+                                modifier = Modifier
+                                    .background(Color.Transparent)
+                            )
+                        }
+                    }
                 }
 
                 Spacer(Modifier.padding(vertical = 20f.dp))
@@ -85,14 +108,31 @@ fun EventLogsView(
                 )
 
                 actualTaskAttempts.value.forEachIndexed { index, taskAttempt ->
-                    Text(
-                        text = taskAttempt.createdAt.toString(),
-                        modifier = Modifier
-                            .padding(16.dp)
-                            .clickable {
-                                actualTaskItemPressed(index)
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = taskAttempt.createdAt.toString(),
+                            modifier = Modifier
+                                .padding(16.dp)
+                                .clickable {
+                                    actualTaskItemPressed(index)
+                                }
+                        )
+
+                        Spacer(modifier = Modifier.weight(1f))
+
+                        IconButton(
+                            onClick = {
+                                eefrtScreenViewModel.deleteTaskAttempt(taskAttempt)
                             }
-                    )
+                        ) {
+                            Image(
+                                imageVector = Icons.Outlined.Delete,
+                                contentDescription = "Delete",
+                                modifier = Modifier
+                                    .background(Color.Transparent)
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EventLogsView.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EventLogsView.kt
@@ -1,0 +1,95 @@
+package ai.a2i2.conductor.effrtdemoandroid.ui
+
+import ai.a2i2.conductor.effrtdemoandroid.R
+import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtScreenViewModel
+import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
+import android.widget.ScrollView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun EventLogsView(
+    eefrtScreenViewModel: EefrtScreenViewModel,
+    onBack: () -> Unit
+) {
+    val practiceTaskAttempts = remember { eefrtScreenViewModel.getPracticeTaskAttempts() }
+    val actualTaskAttempts = remember { eefrtScreenViewModel.getActualTaskAttempts() }
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = {
+                            dismiss(onBack)
+                        }
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.arrow_left),
+                            contentDescription = "Back",
+                        )
+                    }
+                }
+            )
+        },
+        content = { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .verticalScroll(scrollState)
+                    .padding(paddingValues)
+            ) {
+                Text(
+                    "Practice Attempts",
+                    modifier = Modifier.padding(8f.dp)
+                )
+
+                for (practiceAttemptData in practiceTaskAttempts.value) {
+                    Text(
+                        text = practiceAttemptData.createdAt.toString(),
+                        modifier = Modifier.padding(8f.dp)
+                    )
+                }
+
+                Spacer(Modifier.padding(vertical = 20f.dp))
+
+                Text(
+                    "Actual Attempts",
+                    modifier = Modifier.padding(8f.dp)
+                )
+
+                for (attemptData in actualTaskAttempts.value) {
+                    Text(
+                        text = attemptData.createdAt.toString(),
+                        modifier = Modifier.padding(8f.dp)
+                    )
+                }
+
+            }
+        }
+    )
+}
+
+private fun dismiss(onBack: () -> Unit) {
+    Handler(Looper.getMainLooper()).post { onBack() }
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -1,0 +1,69 @@
+package ai.a2i2.conductor.effrtdemoandroid.ui.data
+
+import ai.a2i2.conductor.effrtdemoandroid.persistence.AppDatabase
+import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
+import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class EefrtScreenViewModel(
+    private val appDatabase: AppDatabase
+) : ViewModel() {
+
+    private val _practiceTrialData = mutableStateOf<List<PracticeTaskAttempt>>(emptyList())
+    private val practiceTrialData: State<List<PracticeTaskAttempt>> = _practiceTrialData
+
+    private val _actualTrialData = mutableStateOf<List<TaskAttempt>>(emptyList())
+    private val actualTrialData: State<List<TaskAttempt>> = _actualTrialData
+
+    init {
+        refreshData()
+    }
+
+    private fun refreshData() {
+        viewModelScope.launch {
+            _practiceTrialData.value =
+                appDatabase.practiceTaskAttemptDao().getAllPracticeTrialEvents()
+            _actualTrialData.value = appDatabase.taskAttemptDao().getAllTrialEvents()
+        }
+    }
+
+    fun getPracticeTaskAttempts(): State<List<PracticeTaskAttempt>> {
+        return practiceTrialData
+    }
+
+    fun savePracticeTaskAttempt(practiceTaskAttempt: PracticeTaskAttempt) {
+        viewModelScope.launch {
+            appDatabase.practiceTaskAttemptDao().insert(practiceTaskAttempt)
+            refreshData()
+        }
+    }
+
+    fun deletePracticeTaskAttempt(practiceTaskAttempt: PracticeTaskAttempt) {
+        viewModelScope.launch {
+            appDatabase.practiceTaskAttemptDao().delete(practiceTaskAttempt)
+            refreshData()
+        }
+    }
+
+    fun getActualTaskAttempts(): State<List<TaskAttempt>> {
+        return actualTrialData
+    }
+
+    fun saveActualTaskAttempt(taskAttempt: TaskAttempt) {
+        viewModelScope.launch {
+            appDatabase.taskAttemptDao().insert(taskAttempt)
+            refreshData()
+        }
+    }
+
+    fun deleteTaskAttempt(taskAttempt: TaskAttempt) {
+        viewModelScope.launch {
+            appDatabase.taskAttemptDao().delete(taskAttempt)
+            refreshData()
+        }
+    }
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtTaskAttempt.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtTaskAttempt.kt
@@ -1,0 +1,3 @@
+package ai.a2i2.conductor.effrtdemoandroid.ui.data
+
+interface EefrtTaskAttempt

--- a/EEFRT Demo Android/build.gradle.kts
+++ b/EEFRT Demo Android/build.gradle.kts
@@ -3,4 +3,5 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/EEFRT Demo Android/gradle/libs.versions.toml
+++ b/EEFRT Demo Android/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.8.2"
 kotlin = "2.0.0"
+kotlin-ksp = "2.0.0-1.0.24"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -11,6 +12,10 @@ composeBom = "2024.04.01"
 navigationCompose = "2.8.8"
 webkit = "1.12.1"
 kotlinxSerialization = "1.5.1"
+roomCommon = "2.6.1"
+roomKtx = "2.6.1"
+roomCompiler = "2.6.1"
+gson = "2.8.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -30,8 +35,13 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "webkit" }
 kotinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+androidx-room-common = { group = "androidx.room", name = "room-common", version.ref = "roomCommon" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "roomKtx" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "roomCompiler" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }

--- a/EEFRT Demo iOS/EEFRT Demo.xcodeproj/project.pbxproj
+++ b/EEFRT Demo iOS/EEFRT Demo.xcodeproj/project.pbxproj
@@ -264,7 +264,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -298,7 +298,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
@@ -3,12 +3,19 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         NavigationStack {
-            VStack {
+            VStack(spacing: 20) {
                 NavigationLink(
                     destination: EEFRTView()
                         .ignoresSafeArea(edges: [.bottom]),
                     label: {
                         Text("Begin EEFRT Task")
+                    }
+                )
+
+                NavigationLink(
+                    destination: EventLogsView(),
+                    label: {
+                        Text("View Event Logs")
                     }
                 )
             }

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRT_DemoApp.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRT_DemoApp.swift
@@ -1,10 +1,15 @@
 import SwiftUI
+import SwiftData
 
 @main
 struct EEFRT_DemoApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .modelContainer(for: [
+                    PracticeTaskResult.self,
+                    TaskResult.self,
+                ])
         }
     }
 }

--- a/EEFRT Demo iOS/EEFRT Demo/EventLogsView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EventLogsView.swift
@@ -1,9 +1,12 @@
+import OSLog
 import SwiftData
 import SwiftUI
 
 struct EventLogsView: View {
     @Query(sort: \PracticeTaskResult.createdAt, order: .reverse) var practiceTaskResults: [PracticeTaskResult]
     @Query(sort: \TaskResult.createdAt, order: .reverse) var taskResults: [TaskResult]
+    
+    @Environment(\.modelContext) private var modelContext
 
     var body: some View {
         List {
@@ -25,6 +28,7 @@ struct EventLogsView: View {
                         )
                     }
                 }
+                .onDelete(perform: deletePracticeTaskResult)
             }
 
             Section("Actual attempts") {
@@ -45,7 +49,34 @@ struct EventLogsView: View {
                         )
                     }
                 }
+                .onDelete(perform: deleteActualTaskResult)
             }
+        }
+    }
+    
+    private func deletePracticeTaskResult(at offsets: IndexSet) {
+        for index in offsets {
+            let practiceTaskResult = practiceTaskResults[index]
+            modelContext.delete(practiceTaskResult)
+        }
+        
+        do {
+            try modelContext.save()
+        } catch {
+            os_log("Unable to save changes to the PracticeTaskResults list")
+        }
+    }
+    
+    private func deleteActualTaskResult(at offsets: IndexSet) {
+        for index in offsets {
+            let taskResult = taskResults[index]
+            modelContext.delete(taskResult)
+        }
+        
+        do {
+            try modelContext.save()
+        } catch {
+            os_log("Unable to save changes to the TaskResults list")
         }
     }
 }

--- a/EEFRT Demo iOS/EEFRT Demo/EventLogsView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EventLogsView.swift
@@ -1,0 +1,51 @@
+import SwiftData
+import SwiftUI
+
+struct EventLogsView: View {
+    @Query(sort: \PracticeTaskResult.createdAt, order: .reverse) var practiceTaskResults: [PracticeTaskResult]
+    @Query(sort: \TaskResult.createdAt, order: .reverse) var taskResults: [TaskResult]
+
+    var body: some View {
+        List {
+            Section("Practice attempts") {
+                ForEach(practiceTaskResults) { result in
+                    VStack {
+                        NavigationLink(
+                            destination: {
+                                do {
+                                    let jsonString = try JsonHelpers.stringify(result)
+                                    return TaskResultDetailsView(jsonString: jsonString)
+                                } catch {
+                                    fatalError("Couldn't stringifiy event log we already stringified...")
+                                }
+                            },
+                            label: {
+                                Text(result.createdAt?.description ?? "Something went wrong")
+                            }
+                        )
+                    }
+                }
+            }
+
+            Section("Actual attempts") {
+                ForEach(taskResults) { result in
+                    VStack {
+                        NavigationLink(
+                            destination: {
+                                do {
+                                    let jsonString = try JsonHelpers.stringify(result)
+                                    return TaskResultDetailsView(jsonString: jsonString)
+                                } catch {
+                                    fatalError("Couldn't stringifiy event log we already stringified...")
+                                }
+                            },
+                            label: {
+                                Text(result.createdAt?.description ?? "Something went wrong")
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/Models/PracticeTaskResult.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/PracticeTaskResult.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SwiftData
+
+@Model
+class PracticeTaskResult: Codable {
+    var createdAt: Date?
+    var pracTrialNo: Int
+    var trialReward: Int
+    var trialEffort: Int
+    var pressCount: Int
+    var pressTimes: [Int]
+    var trialSuccess: Int
+    var gemsRunningTotal: Int
+    var maxPressCount: Int
+
+    init(pracTrialNo: Int, trialReward: Int, trialEffort: Int, pressCount: Int, pressTimes: [Int], trialSuccess: Int, gemsRunningTotal: Int, maxPressCount: Int) {
+        self.createdAt = Date()
+        self.pracTrialNo = pracTrialNo
+        self.trialReward = trialReward
+        self.trialEffort = trialEffort
+        self.pressCount = pressCount
+        self.pressTimes = pressTimes
+        self.trialSuccess = trialSuccess
+        self.gemsRunningTotal = gemsRunningTotal
+        self.maxPressCount = maxPressCount
+    }
+
+    required init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+        self.pracTrialNo = try container.decode(Int.self, forKey: .pracTrialNo)
+        self.trialReward = try container.decode(Int.self, forKey: .trialReward)
+        self.trialEffort = try container.decode(Int.self, forKey: .trialEffort)
+        self.pressCount = try container.decode(Int.self, forKey: .pressCount)
+        self.pressTimes = try container.decode([Int].self, forKey: .pressTimes)
+        self.trialSuccess = try container.decode(Int.self, forKey: .trialSuccess)
+        self.gemsRunningTotal = try container.decode(Int.self, forKey: .gemsRunningTotal)
+        self.maxPressCount = try container.decode(Int.self, forKey: .maxPressCount)
+    }
+    
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(pracTrialNo, forKey: .pracTrialNo)
+        try container.encode(trialReward, forKey: .trialReward)
+        try container.encode(trialEffort, forKey: .trialEffort)
+        try container.encode(pressCount, forKey: .pressCount)
+        try container.encode(pressTimes, forKey: .pressTimes)
+        try container.encode(trialSuccess, forKey: .trialSuccess)
+        try container.encode(gemsRunningTotal, forKey: .gemsRunningTotal)
+        try container.encode(maxPressCount, forKey: .maxPressCount)
+
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case createdAt, pracTrialNo, trialReward, trialEffort, pressCount, pressTimes, trialSuccess, gemsRunningTotal, maxPressCount
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/Models/TaskResult.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/TaskResult.swift
@@ -1,0 +1,97 @@
+import Foundation
+import SwiftData
+
+@Model
+class TaskResult: Codable {
+    var createdAt: Date?
+    var trialNo: Int
+    var trialStartTime: Int
+    var trialReward1: Int
+    var trialEffort1: Int
+    var trialEffortPropMax1: Double
+    var trialReward2: Int
+    var trialEffort2: Int
+    var trialEffortPropMax2: Double
+    var choice: String
+    var choiceRT: Int
+    var pressCount: Int
+    var pressTimes: [Int]
+    var trialSuccess: Int
+    var coinsRunningTotal: Int
+    var trialEndTime: Int
+    var effortTimeLimit: Int
+    var recalibration: Int
+    var thresholdMax: Int
+
+    init(trialNo: Int, trialStartTime: Int, trialReward1: Int, trialEffort1: Int, trialEffortPropMax1: Double, trialReward2: Int, trialEffort2: Int, trialEffortPropMax2: Double, choice: String, choiceRT: Int, pressCount: Int, pressTimes: [Int], trialSuccess: Int, coinsRunningTotal: Int, trialEndTime: Int, effortTimeLimit: Int, recalibration: Int, thresholdMax: Int) {
+        self.createdAt = Date()
+        self.trialNo = trialNo
+        self.trialStartTime = trialStartTime
+        self.trialReward1 = trialReward1
+        self.trialEffort1 = trialEffort1
+        self.trialEffortPropMax1 = trialEffortPropMax1
+        self.trialReward2 = trialReward2
+        self.trialEffort2 = trialEffort2
+        self.trialEffortPropMax2 = trialEffortPropMax2
+        self.choice = choice
+        self.choiceRT = choiceRT
+        self.pressCount = pressCount
+        self.pressTimes = pressTimes
+        self.trialSuccess = trialSuccess
+        self.coinsRunningTotal = coinsRunningTotal
+        self.trialEndTime = trialEndTime
+        self.effortTimeLimit = effortTimeLimit
+        self.recalibration = recalibration
+        self.thresholdMax = thresholdMax
+    }
+
+    required init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+        self.trialNo = try container.decode(Int.self, forKey: .trialNo)
+        self.trialStartTime = try container.decode(Int.self, forKey: .trialStartTime)
+        self.trialReward1 = try container.decode(Int.self, forKey: .trialReward1)
+        self.trialEffort1 = try container.decode(Int.self, forKey: .trialEffort1)
+        self.trialEffortPropMax1 = try container.decode(Double.self, forKey: .trialEffortPropMax1)
+        self.trialReward2 = try container.decode(Int.self, forKey: .trialReward2)
+        self.trialEffort2 = try container.decode(Int.self, forKey: .trialEffort2)
+        self.trialEffortPropMax2 = try container.decode(Double.self, forKey: .trialEffortPropMax2)
+        self.choice = try container.decode(String.self, forKey: .choice)
+        self.choiceRT = try container.decode(Int.self, forKey: .choiceRT)
+        self.pressCount = try container.decode(Int.self, forKey: .pressCount)
+        self.pressTimes = try container.decode([Int].self, forKey: .pressTimes)
+        self.trialSuccess = try container.decode(Int.self, forKey: .trialSuccess)
+        self.coinsRunningTotal = try container.decode(Int.self, forKey: .coinsRunningTotal)
+        self.trialEndTime = try container.decode(Int.self, forKey: .trialEndTime)
+        self.effortTimeLimit = try container.decode(Int.self, forKey: .effortTimeLimit)
+        self.recalibration = try container.decode(Int.self, forKey: .recalibration)
+        self.thresholdMax = try container.decode(Int.self, forKey: .thresholdMax)
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(trialNo, forKey: .trialNo)
+        try container.encode(trialStartTime, forKey: .trialStartTime)
+        try container.encode(trialReward1, forKey: .trialReward1)
+        try container.encode(trialEffort1, forKey: .trialEffort1)
+        try container.encode(trialEffortPropMax1, forKey: .trialEffortPropMax1)
+        try container.encode(trialReward2, forKey: .trialReward2)
+        try container.encode(trialEffort2, forKey: .trialEffort2)
+        try container.encode(trialEffortPropMax2, forKey: .trialEffortPropMax2)
+        try container.encode(choice, forKey: .choice)
+        try container.encode(choiceRT, forKey: .choiceRT)
+        try container.encode(pressCount, forKey: .pressCount)
+        try container.encode(pressTimes, forKey: .pressTimes)
+        try container.encode(trialSuccess, forKey: .trialSuccess)
+        try container.encode(coinsRunningTotal, forKey: .coinsRunningTotal)
+        try container.encode(trialEndTime, forKey: .trialEndTime)
+        try container.encode(effortTimeLimit, forKey: .effortTimeLimit)
+        try container.encode(recalibration, forKey: .recalibration)
+        try container.encode(thresholdMax, forKey: .thresholdMax)
+    }
+
+    enum CodingKeys: CodingKey {
+        case createdAt, trialNo, trialStartTime, trialReward1, trialEffort1, trialEffortPropMax1, trialReward2, trialEffort2, trialEffortPropMax2, choice, choiceRT, pressCount, pressTimes, trialSuccess, coinsRunningTotal, trialEndTime, effortTimeLimit, recalibration, thresholdMax
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/TaskResultDetailsView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/TaskResultDetailsView.swift
@@ -1,0 +1,25 @@
+import SwiftData
+import SwiftUI
+
+struct TaskResultDetailsView: View {
+    private var jsonString: String
+    
+    init(jsonString: String) {
+        let formattedString = jsonString
+            .replacingOccurrences(of: ",", with: ",\n")
+            .replacingOccurrences(of: "{", with: "")
+            .replacingOccurrences(of: "}", with: "")
+        
+        self.jsonString = formattedString
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text(jsonString)
+                    .multilineTextAlignment(.leading)
+                    .frame(width: UIScreen.main.bounds.width)
+            }
+        }
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/Utills/Stringify.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Utills/Stringify.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum JsonHelpers {
+    static func stringify<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+
+        let data = try encoder.encode(value)
+        let jsonString = String(decoding: data, as: UTF8.self)
+
+        return jsonString
+    }
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To avoid CORS issues we are using a small Express.js server to serve the files i
 1. Navigate to the `/public` folder
 2. Switch to the required version of node
 3. Run `npm install` to install the required dependencies
-4. Start the server using `node index.js`
+4. Start the server using `npm run start`. Alternatively you can also run the server using `npm run dev` which enables auto-restarting when making changes to the codebase
 
 ## Running the EEFRT task on an iOS
 1. Ensure you have the local file server running before running the app.

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -599,6 +599,8 @@ var trialEnd = function () {
                                      });
 
     // save data
+    EmbedContext.sendMessage("trialResult", this.registry.get("trial" + trial));
+    console.log(this.registry.get("trial" + trial));
     // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
     //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]
 

--- a/public/js/scenes/practiceTask.js
+++ b/public/js/scenes/practiceTask.js
@@ -369,6 +369,8 @@ var pracTrialEnd = function () {
                                               maxPressCount: this.registry.get('maxPressCount')
                                              });
     // save data
+    console.log(this.registry.get("pracTrial"+pracTrial));
+    EmbedContext.sendMessage("practiceTrialResult", this.registry.get("pracTrial"+pracTrial));
     // savePracTaskData(pracTrial, this.registry.get(`pracTrial${pracTrial}`));    // [for firebase]
     //saveTrialDataPav(this.registry.get(`pracTrial${pracTrial}`));             // [for Pavlovia deployment]
     

--- a/public/package-lock.json
+++ b/public/package-lock.json
@@ -12,6 +12,9 @@
         "express": "^4.21.2",
         "path": "^0.12.7",
         "phaser": "^3.23.0"
+      },
+      "devDependencies": {
+        "nodemon": "^3.1.9"
       }
     },
     "node_modules/accepts": {
@@ -26,10 +29,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -37,6 +59,18 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/body-parser": {
@@ -60,6 +94,28 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/bytes": {
@@ -96,6 +152,36 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -290,6 +376,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -321,6 +419,20 @@
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -366,6 +478,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -375,6 +499,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/has-symbols": {
@@ -425,6 +558,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
+    },
     "node_modules/imports-loader": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.8.0.tgz",
@@ -456,6 +595,48 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/json5": {
@@ -544,6 +725,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -563,6 +756,66 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nodemon/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -621,6 +874,18 @@
         "path": "^0.12.7"
       }
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -640,6 +905,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
     },
     "node_modules/qs": {
       "version": "6.13.0",
@@ -677,6 +948,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -700,6 +983,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -824,6 +1119,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.0.tgz",
@@ -840,12 +1147,45 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
       }
     },
     "node_modules/type-is": {
@@ -859,6 +1199,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/public/package.json
+++ b/public/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
+    "dev": "nodemon index.js --ext *",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
@@ -13,5 +14,8 @@
     "express": "^4.21.2",
     "path": "^0.12.7",
     "phaser": "^3.23.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.9"
   }
 }


### PR DESCRIPTION
## Why did I make these changes?
<!-- 
  Link to the issue e.g. https://a2i2.atlassian.net/browse/EC-10 or just EC-10 if Autolink References are enabled.
  See: https://github.blog/2019-10-14-introducing-autolink-references/
  If you do not have a ticket, create one (with a description of the motivation for your changes).
-->
https://deakinuniversity.atlassian.net/browse/CON-2555

## Acceptance Criteria
<!--
  A task list of the acceptance criteria from the associated ticket, e.g.:
  - [ ] Acceptance Criteria 1
  - [ ] Acceptance Criteria 2
  If no acceptance criteria exists, enter "🚫"

  In addition to these acceptance criteria, it is expected that all PRs meet the standards for code quality and correctness
  as outlined here: https://docs.google.com/document/d/1wcn7zbp2X9bWUDApq8MeFqZHo3IEiv0-shc0qXNEYVI
-->
- [x] Implement a way to visualise the responses within the mobile apps

## What are the changes?
<!--
  Give a brief summary of what has changed in this PR, and how those changes were implemented.
  This is to provide context for the list of changes.
-->
- Added a new `npm run dev` config which auto-restarts the server when the web code is changed
- The web app now bubbles up the practice/actual trial results to the mobile apps
- The mobile listens captures and stores the responses in a local DB (SwiftData/Room)
- The mobile apps now have the ability to view the responses in more detail by clicking on a list item tile

## Checklist
<!-- 
  Placing an [x] in the [ ] will mark it as done.
  Please mark all these points to confirm they are completed or not applicable.
-->
- [x] Existing, relevant documentation has been updated to reflect my changes <!-- For example any changes or additions to the build/run scripts should be reflected in the README.md -->
 
## Testing this PR
<!--
  Describe the steps required to test your changes, assuming the starting point of a clean check-out of the project.
  This should include any required data population steps or changes to the environment that differs from the project setup
  instructions in the project's README.md file, as well as any steps within the UI to produce the necessary conditions to
  assess the functional changes.
-->
 **Tests:**
- [x] The feature has been tested in the running application

**Test Instructions:**
Running the web server with the new config
1) navigate to the `/public` folder in a terminal session
2) Run `npm install` to get the new packages added
3) Run `npm run dev` to start the server

Testing the other changes (on both platforms):
1) Start the apps
2) Begin the eefrt task, complete the practice trials and at least 1 of the actual trials
3) Exit the task and return back to the home screen
4) You'll see the new button to view the event logs, view them and you'll see the list containing them in reverse chronological order
5) Tap on both a Practice and Actual trial attempt and you'll see the fields and values submitted from that attempt
6) You can also delete an entry on ios by swiping on the item from right to left. On android you can press the trash can icon to the right of the entry.

## Screenshots or example output
<!--
  If you made any visual changes, include screenshot(s) here.
  On MacOS you can create a screenshot using Command+Shift+4, then drag the file here from the desktop.
  If the changes introduced result in some kind of output, include an example output file here; e.g. data exported
  as a CSV file, or a PDF.
  If not relevant, delete this section.
-->
| Home iOS | Home Android | Event Logs iOS | Event Logs Android | Item Details iOS | Item Details Android |
| --- | --- | --- | --- | --- | --- |
| <img width="375" alt="image" src="https://github.com/user-attachments/assets/29d5ae9b-a820-429a-9ba7-8fb2042e8c79" /> | <img width="404" alt="image" src="https://github.com/user-attachments/assets/cc87bd69-7bf2-4682-8c04-d28aaf9365e7" /> | <img width="381" alt="image" src="https://github.com/user-attachments/assets/7b772b84-b729-4049-ad96-ff1a9776e0d9" /> | <img width="405" alt="image" src="https://github.com/user-attachments/assets/c1914541-5f07-4ac8-aa19-d0485a809c06" /> | <img width="383" alt="image" src="https://github.com/user-attachments/assets/97b2d773-b9d6-4526-ab83-503b85043570" /> | <img width="407" alt="image" src="https://github.com/user-attachments/assets/01abfade-ab05-4600-996b-1893c234e8c8" /> |





