### PR TITLE
Add in a configurable delay before starting the powerup timer [CON-2561]

### DIFF
--- a/public/js/elements/timerPanelClicks.js
+++ b/public/js/elements/timerPanelClicks.js
@@ -2,13 +2,14 @@
 
 // import our custom events centre for passsing info between scenes
 import eventsCenter from '../eventsCenter.js'
+import { powerupDelay } from '../versionInfo.js'
 
 // initiliaze timer variables
 var timedEvent;
 var timedEvent2;
 
 export default class TimerPanel {
-    constructor(scene, x, y, timeLimit, trialEffort, practiceOrReal) {
+    constructor(scene, x, y, timeLimit, trialEffort, practiceOrReal, coundownDelay = powerupDelay) {
         this.scene = scene; 
         
         // initialize time left and press count variables (attach to scene to pass between elements)
@@ -41,17 +42,35 @@ export default class TimerPanel {
         //.drawBounds(scene.add.graphics(), 0xff0000)   // for debugging only
         .popUp(500); 
         
-        // every 200ms call updateTimer function (to update 'time left' text in panel)
-        var timerDelay = 200;    
-        var timerRepeat = (timeLimit/timerDelay)-1;
-        timedEvent = scene.time.addEvent({ delay: timerDelay, callback: updateTimer, 
-                                               args: [scene, trialEffort, timeText, timeLimit, timerDelay, mainPanel, practiceOrReal],
-                                               callbackScope: this, repeat: timerRepeat });
+        setTimeout(() => {
+            // every 200ms call updateTimer function (to update 'time left' text in panel)
+            const timerDelay = 200;    
+            const timerRepeat = (timeLimit / timerDelay) - 1;
+            
+            timedEvent = scene.time.addEvent({ 
+                delay: timerDelay, 
+                callback: updateTimer, 
+                args: [
+                    scene, 
+                    trialEffort, 
+                    timeText, 
+                    timeLimit, 
+                    timerDelay, 
+                    mainPanel, 
+                    practiceOrReal
+                ],
+                callbackScope: this, 
+                repeat: timerRepeat 
+            });
         
-        // and at end of time limit call endTimer function (to end timer panel scene)
-        timedEvent2 = scene.time.addEvent({ delay: timeLimit, callback: endTimer, 
-                                                args: [scene, mainPanel, practiceOrReal],
-                                                callbackScope: this });
+            // and at end of time limit call endTimer function (to end timer panel scene)
+            timedEvent2 = scene.time.addEvent({ 
+                delay: timeLimit, 
+                callback: endTimer, 
+                args: [scene, mainPanel, practiceOrReal],
+                callbackScope: this 
+            }); 
+        }, coundownDelay);
     }
     
    update() { }

--- a/public/js/versionInfo.js
+++ b/public/js/versionInfo.js
@@ -19,6 +19,7 @@ var catchIdx = 13; // specify the catch trial manually
 // End behaviour: 
 var complete_link = "https://app.prolific.co/submissions/complete?cc=8B6EC8FC";  // link offered by brain explorer
 var buttonText = "Go back"; // text to display on the final button
+var powerupDelay = 200; // delay in ms before powerup timer is started
 
 // remainder of settings are automatic (except Practice parameters below)
 // define the possible scene orders as constants
@@ -99,4 +100,4 @@ export {demo_mode,
 	debug_mode, sceneOrder, randomiseOrder, runPractice,
 	completionMin, completionBonus80, completionBonus100, taskName, version, gameType, approxTime, bonusRate, maxBonus,
 	blockDesktop, trialsFile, questionsFile, nTrials, catchIdx, maxCoins, thresholdAutoSet,
-	effortTime, gemHeights, pracTrialRewards, pracTrialEfforts, minPressMax, nCalibrates, nBlocks, complete_link, buttonText};
+	effortTime, gemHeights, pracTrialRewards, pracTrialEfforts, minPressMax, nCalibrates, nBlocks, complete_link, buttonText, powerupDelay};


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2561

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
`versionInfo.js` - Added a default delay for the powerup timer to 200 ms
`timerPanelClicks.js` - Now uses the new `defaultDelay` to delay hooking up the timers for the power up scene

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the task, you should notice a slight delay in both the practice and actual trial runs where the timer text remains at 10.00 before it begins to tick down.

You can also stick console logs at the start of the `setTimeout` block and in the `updateTimer` method to view the delay in the console if you'd like

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Before | After |
| --- | --- |
| https://github.com/user-attachments/assets/b37351fa-88a9-4385-b463-0e1f88b39698 | https://github.com/user-attachments/assets/8ebd0b7b-48cb-474b-b67f-42eede392a2e |