### PR TITLE
Clamp the random index to the within the bounds of the trials array [CON-2562]

### DIFF
--- a/public/js/saveData.js
+++ b/public/js/saveData.js
@@ -79,6 +79,7 @@ import { userHash, attemptHash} from "./getUserBEX.js";
 //     }, { merge: true });
 // };
 
+const clamp = (val, min, max) => Math.min(Math.max(val, min), max);
 // function to shuffle trials
 var shuffleTrials= function (nTrials, catchIdx, nCalibrates) {
     // Create a shuffled array of trial indices
@@ -93,7 +94,7 @@ var shuffleTrials= function (nTrials, catchIdx, nCalibrates) {
     // If catchIdx is below nCalibrates, swap it with an alternative random value >= nCalibrates
     if (catchIdxIndex < nCalibrates) {
         // Find a random index from nCalibrates to nTrials
-        const randomIndex = Math.floor(Math.random() * (nTrials - nCalibrates)) + nCalibrates;
+        const randomIndex = clamp(Math.floor(Math.random() * (nTrials - nCalibrates)) + nCalibrates, 0, nTrials - 1);
 
         // Swap catchIdx with the random index
         [trialIndices[catchIdxIndex], trialIndices[randomIndex]] = [trialIndices[randomIndex], trialIndices[catchIdxIndex]];


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2562

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
When shortening the number of trials and the catch index the choicePanel can sometimes come up as undefined for the reward and effort values, this PR clamps the random trial index generated during the trial generation to be within the bounds of the array.

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1) In `versionInfo.js`, change the following properties:
`nTrials` to 2
`catchIdx` to 0

2) Run the task a few times, you'd notice that on the actual trial attempts the undefined behaviour will not appear again.