### PR TITLE
Add in the paused state [CON-2576]

### DIFF
--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/BottomScreenDialog.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/BottomScreenDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -121,8 +122,8 @@ fun BottomScreenDialog(
                         .fillMaxWidth(0.9F)
                 ) {
                     Text(
-                        config.actionButtonText,
-                        fontSize = 16.sp
+                        config.actionButtonText.uppercase(),
+                        fontSize = 16.sp,
                     )
                 }
 

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/BottomScreenDialog.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/BottomScreenDialog.kt
@@ -7,10 +7,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
@@ -23,7 +21,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -34,12 +31,14 @@ data class BottomScreenDialogConfig(
     val durationSeconds: Int,
     val actionButtonText: String,
     val actionButtonHandler: () -> Unit,
-    val timeoutHandler: () -> Unit
+    val timeoutHandler: () -> Unit,
 )
+
+val red = Color(214, 66, 4)
 
 @Composable
 fun BottomScreenDialog(
-    config: BottomScreenDialogConfig
+    config: BottomScreenDialogConfig,
 ) {
     Column(
         modifier = Modifier
@@ -108,22 +107,23 @@ fun BottomScreenDialog(
                 Button(
                     colors = ButtonDefaults.buttonColors(
                         containerColor = Color.White,
-                        contentColor = Color(255, 125, 125),
+                        contentColor = red,
                     ),
                     onClick = config.actionButtonHandler,
                     modifier = Modifier
+                        .height(60.dp)
                         .border(
                             BorderStroke(
-                                4.dp,
-                                Color(255, 125, 125)
+                                2.dp,
+                                red
                             ),
-                            shape = RoundedCornerShape(25.dp)
+                            shape = RoundedCornerShape(100.dp)
                         )
                         .fillMaxWidth(0.9F)
                 ) {
                     Text(
                         config.actionButtonText.uppercase(),
-                        fontSize = 16.sp,
+                        fontSize = 16.sp
                     )
                 }
 

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/BottomScreenDialog.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/BottomScreenDialog.kt
@@ -1,0 +1,148 @@
+package ai.a2i2.conductor.effrtdemoandroid.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+data class BottomScreenDialogConfig(
+    val titleText: String,
+    val subtitleText: String,
+    val durationSeconds: Int,
+    val actionButtonText: String,
+    val actionButtonHandler: () -> Unit,
+    val timeoutHandler: () -> Unit
+)
+
+@Composable
+fun BottomScreenDialog(
+    config: BottomScreenDialogConfig
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0x66000000))
+    ) {
+        Spacer(
+            modifier = Modifier.weight(1f)
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 25.dp,
+                        topEnd = 25.dp,
+                        bottomStart = 0.dp,
+                        bottomEnd = 0.dp,
+                    )
+                )
+                .background(Color.White)
+        ) {
+            Row {
+
+            }
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxWidth()
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.padding(
+                        horizontal = 18.dp,
+                        vertical = 24.dp
+                    )
+                ) {
+                    Text(
+                        config.titleText,
+                        textAlign = TextAlign.Center,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier
+                            .padding(horizontal = 8.dp)
+                    )
+
+                    Row {
+                        Spacer(modifier = Modifier.weight(1f))
+
+                        TimeProgressView(
+                            durationSeconds = config.durationSeconds,
+                            onTimeUpHandler = config.timeoutHandler
+                        )
+                    }
+                }
+
+                Text(
+                    config.subtitleText,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp)
+                        .padding(bottom = 24.dp)
+                )
+
+                Button(
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.White,
+                        contentColor = Color(255, 125, 125),
+                    ),
+                    onClick = config.actionButtonHandler,
+                    modifier = Modifier
+                        .border(
+                            BorderStroke(
+                                4.dp,
+                                Color(255, 125, 125)
+                            ),
+                            shape = RoundedCornerShape(25.dp)
+                        )
+                        .fillMaxWidth(0.9F)
+                ) {
+                    Text(
+                        config.actionButtonText,
+                        fontSize = 16.sp
+                    )
+                }
+
+                Spacer(Modifier.height(24.dp))
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+fun BottomScreenDialogPreview() {
+    BottomScreenDialog(
+        BottomScreenDialogConfig(
+            titleText = "Are you still there?",
+            subtitleText = "Continue within the next 2 mins to keep collecting coins.",
+            durationSeconds = 120,
+            actionButtonText = "Continue",
+            actionButtonHandler = {},
+            timeoutHandler = {}
+        )
+    )
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -13,7 +13,11 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
@@ -24,6 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.viewinterop.AndroidView
@@ -67,48 +72,68 @@ fun EefrtScreen(
             )
         },
         content = { paddingValues ->
-            AndroidView(
-                factory = {
-                    // https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader
-                    // We use a WebViewAssetLoader to load the files as if they're being hosted via a server.
-                    // This is a safer and compatible with Same-Origin policy (CORS)–a CORS error was being thrown
-                    // because our HTML file links JS files in another directory.
-                    val assetLoader = WebViewAssetLoader.Builder()
-                        // Handler class to open a file from assets directory in the application APK.
-                        .addPathHandler("/assets/", AssetsPathHandler(it))
-                        .build()
-                    WebView.setWebContentsDebuggingEnabled(true)
-                    val realWebView = WebView(it)
-                    webView.value = realWebView
-                    realWebView.apply {
-                        layoutParams = ViewGroup.LayoutParams(
-                            MATCH_PARENT,
-                            MATCH_PARENT
-                        )
-                        webViewClient = object : WebViewClientCompat() {
-                            override fun shouldInterceptRequest(
-                                view: WebView?,
-                                request: WebResourceRequest?
-                            ): WebResourceResponse? {
-                                // Attempt to resolve the url to an application resource or asset
-                                return request?.let { req ->
-                                    assetLoader.shouldInterceptRequest(req.url)
+            Box(contentAlignment = Alignment.Center) {
+                AndroidView(
+                    factory = {
+                        // https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader
+                        // We use a WebViewAssetLoader to load the files as if they're being hosted via a server.
+                        // This is a safer and compatible with Same-Origin policy (CORS)–a CORS error was being thrown
+                        // because our HTML file links JS files in another directory.
+                        val assetLoader = WebViewAssetLoader.Builder()
+                            // Handler class to open a file from assets directory in the application APK.
+                            .addPathHandler("/assets/", AssetsPathHandler(it))
+                            .build()
+                        WebView.setWebContentsDebuggingEnabled(true)
+                        val realWebView = WebView(it)
+                        webView.value = realWebView
+                        realWebView.apply {
+                            layoutParams = ViewGroup.LayoutParams(
+                                MATCH_PARENT,
+                                MATCH_PARENT
+                            )
+                            webViewClient = object : WebViewClientCompat() {
+                                override fun shouldInterceptRequest(
+                                    view: WebView?,
+                                    request: WebResourceRequest?
+                                ): WebResourceResponse? {
+                                    // Attempt to resolve the url to an application resource or asset
+                                    return request?.let { req ->
+                                        assetLoader.shouldInterceptRequest(req.url)
+                                    }
                                 }
                             }
+                            settings.javaScriptEnabled = true
+                            addJavascriptInterface(
+                                EefrtWebInterface { message ->
+                                    handleMessage(
+                                        message,
+                                        onBack,
+                                        exitRequested,
+                                        eefrtViewModel,
+                                        webView.value
+                                    )
+                                },
+                                "AndroidBridge"
+                            )
+                            // An unused domain reserved for Android applications to intercept requests for app assets.
+                            loadUrl("https://$DEFAULT_DOMAIN/assets/index.html")
                         }
-                        settings.javaScriptEnabled = true
-                        addJavascriptInterface(
-                            EefrtWebInterface { message ->
-                                handleMessage(message, onBack, exitRequested, eefrtViewModel)
-                            },
-                            "AndroidBridge"
+                    },
+                    Modifier.padding(top = paddingValues.calculateTopPadding())
+                )
+
+                AnimatedVisibility(
+                    visible = eefrtViewModel.bottomScreenDialogVisible.value,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    eefrtViewModel.getBottomScreenConfig()?.let {
+                        BottomScreenDialog(
+                            config = eefrtViewModel.getBottomScreenConfig()!!
                         )
-                        // An unused domain reserved for Android applications to intercept requests for app assets.
-                        loadUrl("https://$DEFAULT_DOMAIN/assets/index.html")
                     }
-                },
-                Modifier.padding(top = paddingValues.calculateTopPadding())
-            )
+                }
+            }
         }
     )
 }
@@ -120,6 +145,7 @@ private fun handleMessage(
     onBack: () -> Unit,
     exitRequested: MutableState<Boolean>,
     eefrtViewModel: EefrtScreenViewModel,
+    maybeWebview: WebView?
 ) {
     try {
         val obj = JSONObject(message)
@@ -152,6 +178,30 @@ private fun handleMessage(
                 val taskAttempt = gson.fromJson(body, TaskAttempt::class.java)
                 taskAttempt.createdAt = Date()
                 eefrtViewModel.saveActualTaskAttempt(taskAttempt)
+            }
+
+            "break" -> {
+                val config = BottomScreenDialogConfig(
+                    titleText = "Break time",
+                    subtitleText = "You're doing an amazing job!\nTake a short break if you need one. The task will automatically continue after 2 minutes.",
+                    actionButtonText = "Continue",
+                    durationSeconds = 120,
+                    actionButtonHandler = {
+                        eefrtViewModel.bottomScreenDialogVisible.value = false
+                        eefrtViewModel.setBottomScreenConfig(null)
+                        maybeWebview?.evaluateJavascript("breakOver();", null)
+                        Log.i(TAG, "hide bottom screen dialog")
+                    },
+                    timeoutHandler = {
+                        eefrtViewModel.bottomScreenDialogVisible.value = false
+                        eefrtViewModel.setBottomScreenConfig(null)
+                        maybeWebview?.evaluateJavascript("breakOver();", null)
+                        Log.i(TAG, "hide bottom screen dialog")
+                    }
+                )
+                eefrtViewModel.setBottomScreenConfig(config)
+                eefrtViewModel.bottomScreenDialogVisible.value = true
+                Log.i(TAG, "Show bottom screen dialog")
             }
 
             else -> Log.i(

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/TimeProgressView.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/TimeProgressView.kt
@@ -1,12 +1,8 @@
 package ai.a2i2.conductor.effrtdemoandroid.ui
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.content.MediaType.Companion.Text
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,23 +13,19 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
-import kotlin.time.Duration
 
 @Composable
 fun TimeProgressView(
     durationSeconds: Int,
-    onTimeUpHandler: () -> Unit
+    onTimeUpHandler: () -> Unit,
 ) {
     var timeLeft by remember { mutableIntStateOf(durationSeconds) }
     val percentage =
@@ -47,40 +39,36 @@ fun TimeProgressView(
         onTimeUpHandler()
     }
 
-    Box(
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
-            .clip(
-                RoundedCornerShape(12.dp)
-            )
-            .background(Color.Gray.copy(alpha = 0.2f))
-            .padding(horizontal = 12.dp, vertical = 3.dp)
+            .background(color = Color(0xFFF2F4F7), shape = RoundedCornerShape(size = 6.dp))
+            .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Box {
-                Canvas(modifier = Modifier.size(20.dp)) {
-                    drawArc(
-                        color = Color.Gray,
-                        startAngle = 270f,
-                        sweepAngle = 360f,
-                        useCenter = true,
-                    )
-                }
-
-                Canvas(modifier = Modifier.size(20.dp)) {
-                    drawArc(
-                        color = Color.Black,
-                        startAngle = 270f,
-                        sweepAngle = 360 * percentage.value,
-                        useCenter = true,
-                    )
-                }
+        Box {
+            Canvas(modifier = Modifier.size(20.dp)) {
+                drawArc(
+                    color = Color(208, 213, 221),
+                    startAngle = 270f,
+                    sweepAngle = 360f,
+                    useCenter = true,
+                )
             }
 
-            Text(
-                formatTimeLeft(timeLeft),
-                modifier = Modifier.padding(start = 4.dp)
-            )
+            Canvas(modifier = Modifier.size(20.dp)) {
+                drawArc(
+                    color = Color(152, 162, 179),
+                    startAngle = 270f,
+                    sweepAngle = 360 * percentage.value,
+                    useCenter = true,
+                )
+            }
         }
+
+        Text(
+            formatTimeLeft(timeLeft),
+            modifier = Modifier.padding(start = 4.dp),
+        )
     }
 }
 

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/TimeProgressView.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/TimeProgressView.kt
@@ -1,0 +1,101 @@
+package ai.a2i2.conductor.effrtdemoandroid.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.content.MediaType.Companion.Text
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
+
+@Composable
+fun TimeProgressView(
+    durationSeconds: Int,
+    onTimeUpHandler: () -> Unit
+) {
+    var timeLeft by remember { mutableIntStateOf(durationSeconds) }
+    val percentage =
+        remember { derivedStateOf { (timeLeft.toFloat() / durationSeconds.toFloat()).coerceAtMost(1f) } }
+
+    LaunchedEffect(key1 = true) {
+        while (timeLeft > 0) {
+            delay(1000)
+            timeLeft--
+        }
+        onTimeUpHandler()
+    }
+
+    Box(
+        modifier = Modifier
+            .clip(
+                RoundedCornerShape(12.dp)
+            )
+            .background(Color.Gray.copy(alpha = 0.2f))
+            .padding(horizontal = 12.dp, vertical = 3.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box {
+                Canvas(modifier = Modifier.size(20.dp)) {
+                    drawArc(
+                        color = Color.Gray,
+                        startAngle = 270f,
+                        sweepAngle = 360f,
+                        useCenter = true,
+                    )
+                }
+
+                Canvas(modifier = Modifier.size(20.dp)) {
+                    drawArc(
+                        color = Color.Black,
+                        startAngle = 270f,
+                        sweepAngle = 360 * percentage.value,
+                        useCenter = true,
+                    )
+                }
+            }
+
+            Text(
+                formatTimeLeft(timeLeft),
+                modifier = Modifier.padding(start = 4.dp)
+            )
+        }
+    }
+}
+
+private fun formatTimeLeft(secondsLeft: Int): String {
+    val minutes = secondsLeft / 60
+    val seconds = secondsLeft % 60
+
+    return if (seconds < 10) "${minutes}:0${seconds}" else "${minutes}:${seconds}"
+}
+
+@Composable
+@Preview
+fun TimeProgressViewPreview() {
+    TimeProgressView(
+        durationSeconds = 120,
+        onTimeUpHandler = {}
+    )
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/TimeProgressView.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/TimeProgressView.kt
@@ -46,7 +46,7 @@ fun TimeProgressView(
             .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         Box {
-            Canvas(modifier = Modifier.size(20.dp)) {
+            Canvas(modifier = Modifier.size(16.dp)) {
                 drawArc(
                     color = Color(208, 213, 221),
                     startAngle = 270f,
@@ -55,7 +55,7 @@ fun TimeProgressView(
                 )
             }
 
-            Canvas(modifier = Modifier.size(20.dp)) {
+            Canvas(modifier = Modifier.size(16.dp)) {
                 drawArc(
                     color = Color(152, 162, 179),
                     startAngle = 270f,

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -3,6 +3,7 @@ package ai.a2i2.conductor.effrtdemoandroid.ui.data
 import ai.a2i2.conductor.effrtdemoandroid.persistence.AppDatabase
 import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
+import ai.a2i2.conductor.effrtdemoandroid.ui.BottomScreenDialogConfig
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -18,6 +19,9 @@ class EefrtScreenViewModel(
 
     private val _actualTrialData = mutableStateOf<List<TaskAttempt>>(emptyList())
     private val actualTrialData: State<List<TaskAttempt>> = _actualTrialData
+
+    private var bottomScreenDialogConfig: BottomScreenDialogConfig? = null
+    var bottomScreenDialogVisible = mutableStateOf(false)
 
     init {
         refreshData()
@@ -65,5 +69,13 @@ class EefrtScreenViewModel(
             appDatabase.taskAttemptDao().delete(taskAttempt)
             refreshData()
         }
+    }
+
+    fun setBottomScreenConfig(config: BottomScreenDialogConfig?) {
+        bottomScreenDialogConfig = config
+    }
+
+    fun getBottomScreenConfig(): BottomScreenDialogConfig? {
+        return bottomScreenDialogConfig
     }
 }

--- a/EEFRT Demo iOS/EEFRT Demo/BottomScreenDialogView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/BottomScreenDialogView.swift
@@ -58,7 +58,7 @@ struct BottomScreenDialogView: View {
                         } label: {
                             ZStack {
                                 RoundedRectangle(cornerRadius: 25)
-                                    .stroke(Color.orange, lineWidth: 4)
+                                    .stroke(Color.orange, lineWidth: 2)
                                     .frame(height: 48)
                                     .foregroundStyle(Color.white)
 

--- a/EEFRT Demo iOS/EEFRT Demo/BottomScreenDialogView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/BottomScreenDialogView.swift
@@ -6,16 +6,14 @@ struct BottomScreenDialogView: View {
     private var subtitleText: String
     private var actionButtonText: String
     private var timeoutSeconds: TimeInterval
-    private var hostingWebview: WKWebView
     private var dismissHandler: () -> Void
     private var timeoutHandler: () -> Void
     
-    init(titleText: String, subtitleText: String, actionButtonText: String, timeoutSeconds: TimeInterval, hostingWebview: WKWebView, dismissHandler: @escaping () -> Void, timeoutHandler: @escaping () -> Void) {
+    init(titleText: String, subtitleText: String, actionButtonText: String, timeoutSeconds: TimeInterval, dismissHandler: @escaping () -> Void, timeoutHandler: @escaping () -> Void) {
         self.titleText = titleText
         self.subtitleText = subtitleText
         self.actionButtonText = actionButtonText
         self.timeoutSeconds = timeoutSeconds
-        self.hostingWebview = hostingWebview
         self.dismissHandler = dismissHandler
         self.timeoutHandler = timeoutHandler
     }
@@ -87,7 +85,6 @@ struct BottomScreenDialogView: View {
         subtitleText: "Continue within the next 2 mins to keep collecting coins.",
         actionButtonText: "Continue",
         timeoutSeconds: 120.0,
-        hostingWebview: WKWebView(),
         dismissHandler: {},
         timeoutHandler: {}
     )

--- a/EEFRT Demo iOS/EEFRT Demo/BottomScreenDialogView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/BottomScreenDialogView.swift
@@ -56,14 +56,15 @@ struct BottomScreenDialogView: View {
                         Button {
                             dismissHandler()
                         } label: {
+                            let color = Color(hex: "#D64204")
                             ZStack {
-                                RoundedRectangle(cornerRadius: 25)
-                                    .stroke(Color.orange, lineWidth: 2)
-                                    .frame(height: 48)
+                                RoundedRectangle(cornerRadius: 100)
+                                    .stroke(color, lineWidth: 2)
+                                    .frame(height: 60)
                                     .foregroundStyle(Color.white)
 
                                 Text(actionButtonText.uppercased())
-                                    .foregroundStyle(Color.orange)
+                                    .foregroundStyle(color)
                                     .bold()
                             }
                         }

--- a/EEFRT Demo iOS/EEFRT Demo/BottomScreenDialogView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/BottomScreenDialogView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import WebKit
+
+struct BottomScreenDialogView: View {
+    private var titleText: String
+    private var subtitleText: String
+    private var actionButtonText: String
+    private var timeoutSeconds: TimeInterval
+    private var hostingWebview: WKWebView
+    private var dismissHandler: () -> Void
+    private var timeoutHandler: () -> Void
+    
+    init(titleText: String, subtitleText: String, actionButtonText: String, timeoutSeconds: TimeInterval, hostingWebview: WKWebView, dismissHandler: @escaping () -> Void, timeoutHandler: @escaping () -> Void) {
+        self.titleText = titleText
+        self.subtitleText = subtitleText
+        self.actionButtonText = actionButtonText
+        self.timeoutSeconds = timeoutSeconds
+        self.hostingWebview = hostingWebview
+        self.dismissHandler = dismissHandler
+        self.timeoutHandler = timeoutHandler
+    }
+    
+    var body: some View {
+        ZStack {
+            Color(hex: "#66000000")
+            
+            VStack {
+                Spacer()
+                
+                ZStack {
+                    UnevenRoundedRectangle(cornerRadii: RectangleCornerRadii(topLeading: 25, topTrailing: 25))
+                        .foregroundStyle(Color.white)
+                    
+                    VStack(spacing: 24) {
+                        ZStack {
+                            Text(titleText)
+                                .multilineTextAlignment(.center)
+                                .font(.system(size: 18, weight: .bold))
+                                .frame(maxWidth: .infinity)
+                            
+                            HStack {
+                                Spacer()
+                                
+                                TimeProgressView(
+                                    countdownSeconds: timeoutSeconds,
+                                    timeoutHandler: timeoutHandler
+                                )
+                                .padding(.trailing)
+                            }
+                        }
+                        .padding(.top)
+                        
+                        Text(subtitleText)
+                            .multilineTextAlignment(.center)
+                            .font(.system(size: 14, weight: .regular))
+                            .padding(.horizontal)
+                        
+                        Button {
+                            dismissHandler()
+                        } label: {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: 25)
+                                    .stroke(Color.orange, lineWidth: 4)
+                                    .frame(height: 48)
+                                    .foregroundStyle(Color.white)
+
+                                Text(actionButtonText.uppercased())
+                                    .foregroundStyle(Color.orange)
+                                    .bold()
+                            }
+                        }
+                        .padding()
+                        .fixedSize(horizontal: false, vertical: false)
+                    }
+                    .padding(.vertical)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .ignoresSafeArea(edges: .bottom)
+    }
+}
+
+#Preview {
+    BottomScreenDialogView(
+        titleText: "Are you still there?",
+        subtitleText: "Continue within the next 2 mins to keep collecting coins.",
+        actionButtonText: "Continue",
+        timeoutSeconds: 120.0,
+        hostingWebview: WKWebView(),
+        dismissHandler: {},
+        timeoutHandler: {}
+    )
+}

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -127,6 +127,7 @@ class EEFRTViewController: UIViewController {
 
         bottomScreenDialogView = UIHostingController(rootView: bottomScreenDialog)
         bottomScreenDialogView?.view.backgroundColor = .clear
+        bottomScreenDialogView?.view.alpha = 0
 
         DispatchQueue.main.async { [weak self] in
             guard let self, let bottomScreenDialogView else { return }
@@ -142,28 +143,35 @@ class EEFRTViewController: UIViewController {
                 bottomScreenDialogView.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 bottomScreenDialogView.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             ])
+
+            UIView.animate { [weak self] in
+                guard let self else { return }
+                self.bottomScreenDialogView?.view.alpha = 1
+            }
         }
     }
 
     private func detatchBottomScreenDialog() {
         DispatchQueue.main.async { [weak self] in
-            guard let self, let bottomScreenDialogView else { return }
+            UIView.animate(withDuration: 0.4, animations: { [weak self] in
+                guard let self, let bottomScreenDialogView else { return }
 
-            bottomScreenDialogView.willMove(toParent: nil)
-            bottomScreenDialogView.view.removeFromSuperview()
-            bottomScreenDialogView.removeFromParent()
-            self.bottomScreenDialogView = nil
-            self.view.layoutIfNeeded()
+                bottomScreenDialogView.view.alpha = 0
+            }) { [weak self] _ in
+                guard let self, let bottomScreenDialogView else { return }
+
+                bottomScreenDialogView.willMove(toParent: nil)
+                bottomScreenDialogView.view.removeFromSuperview()
+                bottomScreenDialogView.removeFromParent()
+                self.bottomScreenDialogView = nil
+                self.view.layoutIfNeeded()
+                self.resumeTask()
+            }
         }
     }
 
     private func resumeTask() {
         webView.evaluateJavaScript("breakOver();")
-    }
-
-    private func removeDialogAndResumeTask() {
-        detatchBottomScreenDialog()
-        resumeTask()
     }
 }
 
@@ -203,14 +211,13 @@ extension EEFRTViewController: WKScriptMessageHandler {
                 subtitleText: "You're doing an amazing job!\nTake a short break if you need one. The task will automatically continue after 2 minutes.",
                 actionButtonText: "Continue",
                 timeoutSeconds: 120,
-                hostingWebview: webView,
                 dismissHandler: { [weak self] in
                     guard let self else { return }
-                    removeDialogAndResumeTask()
+                    detatchBottomScreenDialog()
                 },
                 timeoutHandler: { [weak self] in
                     guard let self else { return }
-                    removeDialogAndResumeTask()
+                    detatchBottomScreenDialog()
                 }
             )
             attachBottomScreenDialog(bottomScreenDialog: bottomScreenDialog)

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -126,6 +126,7 @@ class EEFRTViewController: UIViewController {
         guard bottomScreenDialogView == nil else { return }
 
         bottomScreenDialogView = UIHostingController(rootView: bottomScreenDialog)
+        bottomScreenDialogView?.view.backgroundColor = .clear
 
         DispatchQueue.main.async { [weak self] in
             guard let self, let bottomScreenDialogView else { return }

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -54,10 +54,12 @@ class EEFRTViewController: UIViewController {
     private static let closedMessageKey = "close"
     private static let practiceTriaResultMessageKey = "practiceTrialResult"
     private static let trialResultMessageKey = "trialResult"
+    private static let breakMessageKey = "break"
 
     weak var delegate: EEFRTViewControllerDelegate?
 
     private var webView: WKWebView!
+    private var bottomScreenDialogView: UIHostingController<BottomScreenDialogView>?
 
     private let publicPath: String
     private let indexFileUrl: URL
@@ -94,6 +96,8 @@ class EEFRTViewController: UIViewController {
         config.userContentController.add(self, name: Self.closedMessageKey)
         config.userContentController.add(self, name: Self.practiceTriaResultMessageKey)
         config.userContentController.add(self, name: Self.trialResultMessageKey)
+        config.userContentController.add(self, name: Self.breakMessageKey)
+
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
 
         webView = WKWebView(frame: .zero, configuration: config)
@@ -116,6 +120,49 @@ class EEFRTViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         webView.loadFileURL(indexFileUrl, allowingReadAccessTo: URL(fileURLWithPath: publicPath))
+    }
+
+    private func attachBottomScreenDialog(bottomScreenDialog: BottomScreenDialogView) {
+        guard bottomScreenDialogView == nil else { return }
+
+        bottomScreenDialogView = UIHostingController(rootView: bottomScreenDialog)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let bottomScreenDialogView else { return }
+
+            bottomScreenDialogView.view.translatesAutoresizingMaskIntoConstraints = false
+            addChild(bottomScreenDialogView)
+            bottomScreenDialogView.view.willMove(toSuperview: view)
+            view.addSubview(bottomScreenDialogView.view)
+
+            NSLayoutConstraint.activate([
+                bottomScreenDialogView.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                bottomScreenDialogView.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                bottomScreenDialogView.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                bottomScreenDialogView.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            ])
+        }
+    }
+
+    private func detatchBottomScreenDialog() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let bottomScreenDialogView else { return }
+
+            bottomScreenDialogView.willMove(toParent: nil)
+            bottomScreenDialogView.view.removeFromSuperview()
+            bottomScreenDialogView.removeFromParent()
+            self.bottomScreenDialogView = nil
+            self.view.layoutIfNeeded()
+        }
+    }
+
+    private func resumeTask() {
+        webView.evaluateJavaScript("breakOver();")
+    }
+
+    private func removeDialogAndResumeTask() {
+        detatchBottomScreenDialog()
+        resumeTask()
     }
 }
 
@@ -148,6 +195,24 @@ extension EEFRTViewController: WKScriptMessageHandler {
             } catch {
                 os_log(.error, "Couldn't decode response from EEFRT task into a native object")
             }
+
+        case Self.breakMessageKey:
+            let bottomScreenDialog = BottomScreenDialogView(
+                titleText: "Break time",
+                subtitleText: "You're doing an amazing job!\nTake a short break if you need one. The task will automatically continue after 2 minutes.",
+                actionButtonText: "Continue",
+                timeoutSeconds: 120,
+                hostingWebview: webView,
+                dismissHandler: { [weak self] in
+                    guard let self else { return }
+                    removeDialogAndResumeTask()
+                },
+                timeoutHandler: { [weak self] in
+                    guard let self else { return }
+                    removeDialogAndResumeTask()
+                }
+            )
+            attachBottomScreenDialog(bottomScreenDialog: bottomScreenDialog)
 
         default:
             os_log(.error, "Message type %s not implemented yet!", message.name)

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -153,7 +153,7 @@ class EEFRTViewController: UIViewController {
 
     private func detatchBottomScreenDialog() {
         DispatchQueue.main.async { [weak self] in
-            UIView.animate(withDuration: 0.4, animations: { [weak self] in
+            UIView.animate(withDuration: 0.3, animations: { [weak self] in
                 guard let self, let bottomScreenDialogView else { return }
 
                 bottomScreenDialogView.view.alpha = 0

--- a/EEFRT Demo iOS/EEFRT Demo/Extensions/Color+Extensions.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Extensions/Color+Extensions.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/TimeProgressView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/TimeProgressView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+import UIKit
+
+struct TimeProgressView: View {
+    private var countdownSeconds: Double
+    private var timeoutHandler: () -> Void
+    
+    @State private var timeLeft: Double
+    @State private var endAngle: Angle = .degrees(360)
+
+    private let clockBackgroundColor: Color = .init(hex: "#666666")
+    private let clockForegroundColor: Color = .init(hex: "#333333")
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    init(countdownSeconds: Double, timeoutHandler: @escaping () -> Void) {
+        self.countdownSeconds = countdownSeconds
+        self.timeLeft = countdownSeconds
+        self.timeoutHandler = timeoutHandler
+    }
+
+    var body: some View {
+        ZStack {
+            HStack(spacing: 4) {
+                GeometryReader { geometry in
+                    ZStack {
+                        Path { path in
+                            let width: CGFloat = min(geometry.size.width, geometry.size.height)
+                            let height = width
+
+                            let center = CGPoint(x: width * 0.5, y: height * 0.5)
+
+                            path.move(to: center)
+
+                            path.addArc(center: center, radius: width * 0.5, startAngle: Angle(degrees: -90.0), endAngle: Angle(degrees: -90.0) + .degrees(360), clockwise: false)
+                        }
+                        .fill(clockBackgroundColor)
+
+                        Path { path in
+                            let width: CGFloat = min(geometry.size.width, geometry.size.height)
+                            let height = width
+
+                            let center = CGPoint(x: width * 0.5, y: height * 0.5)
+
+                            path.move(to: center)
+
+                            path.addArc(center: center, radius: width * 0.5, startAngle: Angle(degrees: -90.0), endAngle: Angle(degrees: -90.0) + endAngle, clockwise: false)
+                        }
+                        .fill(clockForegroundColor)
+                    }
+                }
+                .frame(width: 20, height: 20, alignment: .center)
+                .aspectRatio(1, contentMode: .fit)
+                .onReceive(timer) { _ in
+                    if timeLeft == 0 {
+                        timer.upstream.connect().cancel()
+                    } else {
+                        timeLeft -= 1
+                        endAngle = Angle(degrees: Double((timeLeft / countdownSeconds) * 360))
+                    }
+                }
+
+                Text("\(timeFormatter(timeRemaining: timeLeft))")
+                    .font(Font.custom("Roboto-Bold", size: 16))
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color.gray.opacity(0.2))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    func timeFormatter(timeRemaining: Double) -> String {
+        let roundedTime = Int(timeRemaining)
+        let minutes = roundedTime / 60
+        let seconds = roundedTime % 60
+
+        return seconds < 10 ? "\(minutes):0\(seconds)" : "\(minutes):\(seconds)"
+    }
+}
+
+struct TimeProgressView_Previews: PreviewProvider {
+    static var previews: some View {
+        TimeProgressView(countdownSeconds: 120, timeoutHandler: {})
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/TimeProgressView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/TimeProgressView.swift
@@ -4,7 +4,7 @@ import UIKit
 struct TimeProgressView: View {
     private var countdownSeconds: Double
     private var timeoutHandler: () -> Void
-    
+
     @State private var timeLeft: Double
     @State private var endAngle: Angle = .degrees(360)
 
@@ -53,6 +53,7 @@ struct TimeProgressView: View {
                 .onReceive(timer) { _ in
                     if timeLeft == 0 {
                         timer.upstream.connect().cancel()
+                        timeoutHandler()
                     } else {
                         timeLeft -= 1
                         endAngle = Angle(degrees: Double((timeLeft / countdownSeconds) * 360))

--- a/EEFRT Demo iOS/EEFRT Demo/TimeProgressView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/TimeProgressView.swift
@@ -8,8 +8,8 @@ struct TimeProgressView: View {
     @State private var timeLeft: Double
     @State private var endAngle: Angle = .degrees(360)
 
-    private let clockBackgroundColor: Color = .init(hex: "#666666")
-    private let clockForegroundColor: Color = .init(hex: "#333333")
+    private let clockBackgroundColor: Color = .init(hex: "#D0D5DD")
+    private let clockForegroundColor: Color = .init(hex: "#98A2B3")
     private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     init(countdownSeconds: Double, timeoutHandler: @escaping () -> Void) {
@@ -48,7 +48,7 @@ struct TimeProgressView: View {
                         .fill(clockForegroundColor)
                     }
                 }
-                .frame(width: 20, height: 20, alignment: .center)
+                .frame(width: 16, height: 16, alignment: .center)
                 .aspectRatio(1, contentMode: .fit)
                 .onReceive(timer) { _ in
                     if timeLeft == 0 {
@@ -64,10 +64,10 @@ struct TimeProgressView: View {
                     .font(Font.custom("Roboto-Bold", size: 16))
             }
         }
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 16)
         .padding(.vertical, 4)
-        .background(Color.gray.opacity(0.2))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .background(Color.init(hex: "#F2F4F7"))
+        .cornerRadius(CGFloat(6))
     }
 
     func timeFormatter(timeRemaining: Double) -> String {

--- a/public/index.html
+++ b/public/index.html
@@ -57,5 +57,12 @@
                 "This browser doesn't support modules, so the study can't run. Please try the latest version of Chrome, Firefox or Safari!"
             );
         </script>
+
+        <script type="module">
+            import eventsCenter from './js/eventsCenter.js';
+            window.breakOver = function() {
+                eventsCenter.emit('breakover');
+            };
+        </script>
     </body>
 </html>

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -660,7 +660,8 @@ var trialEnd = function () {
 
     // if end of task, display taskend screen 
     // if end of block, display end of block screen
-    if ((trial==(nTrials/nBlocks - 1) && trial != nTrials - 1)) {
+    let trialsPerBlock = nTrials / nBlocks;
+    if ((trial + 1) % trialsPerBlock == 0 && trial != nTrials - 1) {
         this.player.sprite.setVelocityX(0);
         this.player.sprite.anims.play('wait', true);
         EmbedContext.sendMessage("break");

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -660,8 +660,7 @@ var trialEnd = function () {
 
     // if end of task, display taskend screen 
     // if end of block, display end of block screen
-    // change to calculate break at halfway only 
-    if ((trial==(nTrials/2))) {
+    if ((trial==(nTrials/nBlocks - 1) && trial != nTrials - 1)) {
         this.player.sprite.setVelocityX(0);
         this.player.sprite.anims.play('wait', true);
         this.breakPanel = new BreakPanel(this, mapWidth-gameWidth/2, 600, nCoins);
@@ -701,4 +700,3 @@ var collectCoins = function(player, coin, trial){
     coinsText.setText('coins: ' + nCoins);  // and coins total and text updates
 
 };
-

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -663,8 +663,9 @@ var trialEnd = function () {
     if ((trial==(nTrials/nBlocks - 1) && trial != nTrials - 1)) {
         this.player.sprite.setVelocityX(0);
         this.player.sprite.anims.play('wait', true);
-        this.breakPanel = new BreakPanel(this, mapWidth-gameWidth/2, 600, nCoins);
-        this.events.once('breakover', function () {
+        EmbedContext.sendMessage("break");
+        // this.breakPanel = new BreakPanel(this, mapWidth-gameWidth/2, 600, nCoins);
+        eventsCenter.once('breakover', function () {
             //  restart coin total from 0 after each block
             // nCoins=0; - keep coins to gamify
             // iterate trial number

--- a/public/js/versionInfo.js
+++ b/public/js/versionInfo.js
@@ -84,7 +84,7 @@ if (runPractice == true) {
 else {
 	var nCalibrates = 0;
 }
-const nBlocks = 2;					
+const nBlocks = 4;					
 
 // 3. time and payment:
 var approxTime = 6;   	// approx time to complete this version of the experiment (minutes)
@@ -97,8 +97,9 @@ var nGames = 8;
 var MaxTotalBonus = completionBonus100 + (nGames * maxBonus);
 var completionMin = 80;
 
-export {demo_mode,
-	debug_mode, sceneOrder, randomiseOrder, runPractice,
+export {
+	demo_mode, debug_mode, sceneOrder, randomiseOrder, runPractice,
 	completionMin, completionBonus80, completionBonus100, taskName, version, gameType, approxTime, bonusRate, maxBonus,
 	blockDesktop, trialsFile, questionsFile, nTrials, catchIdx, maxCoins, thresholdAutoSet,
-	effortTime, timeout, gemHeights, pracTrialRewards, pracTrialEfforts, minPressMax, nCalibrates, nBlocks, complete_link, buttonText, powerupDelay};
+	effortTime, timeout, gemHeights, pracTrialRewards, pracTrialEfforts, minPressMax, nCalibrates, nBlocks, complete_link, buttonText, powerupDelay
+};


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2576

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Updated the task flow to now be in 4 blocks
- Added custom bottom screen dialogs to both the iOS and Android apps which now appear when a break is reached

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On both iOS and Android:
1) Run the app and run the task
2) At the end of blocks 6, 12, and 18 you'll get the dialog message.
3) Ensure you test both scenarios where you press the dialog action button and also when the timer times out

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| iOS | Android |
| --- | --- |
| <img width="375" alt="image" src="https://github.com/user-attachments/assets/fe2c8337-48dd-4453-a979-454042ca7768" /> | <img width="412" alt="image" src="https://github.com/user-attachments/assets/17b3ac88-16e2-4d2d-9d93-a65dbb07edee" /> |


