### PR TITLE
Update the success/failure/timeout dialogs [CON-2582]

### DIFF
--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
@@ -22,7 +22,7 @@ data class PracticeTaskAttempt(
     @ColumnInfo(name = "trial_success") val trialSuccess: Int,
     @ColumnInfo(name = "gems_running_total") val gemsRunningTotal: Int,
     @ColumnInfo(name = "max_press_count") val maxPressCount: Int,
-): EefrtTaskAttempt
+) : EefrtTaskAttempt
 
 @Dao
 interface PracticeTaskAttemptDao {
@@ -34,4 +34,7 @@ interface PracticeTaskAttemptDao {
 
     @Query("SELECT * FROM practice_trial_events ORDER BY created_at DESC")
     suspend fun getAllPracticeTrialEvents(): List<PracticeTaskAttempt>
+
+    @Query("DELETE FROM practice_trial_events")
+    suspend fun deleteAllEvents()
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/TaskAttemptDto.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/TaskAttemptDto.kt
@@ -44,4 +44,7 @@ interface TaskAttemptDto {
 
     @Query("SELECT * FROM trial_attempt_events ORDER BY created_at DESC")
     suspend fun getAllTrialEvents(): List<TaskAttempt>
+
+    @Query("DELETE FROM trial_attempt_events")
+    suspend fun deleteAllEvents()
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EventLogsView.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EventLogsView.kt
@@ -17,12 +17,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,10 +40,10 @@ fun EventLogsView(
     practiceTaskItemPressed: (Int) -> Unit,
     actualTaskItemPressed: (Int) -> Unit,
     onBack: () -> Unit,
-
-    ) {
+) {
     val practiceTaskAttempts = remember { eefrtScreenViewModel.getPracticeTaskAttempts() }
     val actualTaskAttempts = remember { eefrtScreenViewModel.getActualTaskAttempts() }
+    val shouldShowDialog = remember { mutableStateOf(false) }
     val scrollState = rememberScrollState()
 
     Scaffold(
@@ -58,6 +61,23 @@ fun EventLogsView(
                             contentDescription = "Back",
                         )
                     }
+                },
+                actions = {
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    IconButton(
+                        onClick = {
+                            shouldShowDialog.value = true
+                        },
+                        modifier = Modifier.padding(end = 0.dp)
+                    ) {
+                        Image(
+                            painter = painterResource(R.drawable.delete_forever_24dp),
+                            contentDescription = "Delete",
+                            modifier = Modifier
+                                .background(Color.Transparent)
+                        )
+                    }
                 }
             )
         },
@@ -66,6 +86,7 @@ fun EventLogsView(
                 modifier = Modifier
                     .verticalScroll(scrollState)
                     .padding(paddingValues)
+                    .padding(horizontal = 4.dp)
             ) {
                 Text(
                     "Practice Attempts",
@@ -133,6 +154,33 @@ fun EventLogsView(
                             )
                         }
                     }
+                }
+
+                if (shouldShowDialog.value) {
+                    AlertDialog(
+                        title = { Text("Delete all event logs") },
+                        text = { Text("Are you sure you want to remove all the practice and actual trial event log data?") },
+                        onDismissRequest = { shouldShowDialog.value = false },
+                        confirmButton = {
+                            Button(
+                                onClick = {
+                                    shouldShowDialog.value = false
+                                    eefrtScreenViewModel.deleteAllEvents()
+                                }
+                            ) {
+                                Text("Delete")
+                            }
+                        },
+                        dismissButton = {
+                            Button(
+                                onClick = {
+                                    shouldShowDialog.value = false
+                                }
+                            ) {
+                                Text("Cancel")
+                            }
+                        }
+                    )
                 }
             }
         }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -78,4 +78,12 @@ class EefrtScreenViewModel(
     fun getBottomScreenConfig(): BottomScreenDialogConfig? {
         return bottomScreenDialogConfig
     }
+
+    fun deleteAllEvents() {
+        viewModelScope.launch {
+            appDatabase.taskAttemptDao().deleteAllEvents()
+            appDatabase.practiceTaskAttemptDao().deleteAllEvents()
+            refreshData()
+        }
+    }
 }

--- a/EEFRT Demo Android/app/src/main/res/drawable/delete_forever_24dp.xml
+++ b/EEFRT Demo Android/app/src/main/res/drawable/delete_forever_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m376,660 l104,-104 104,104 56,-56 -104,-104 104,-104 -56,-56 -104,104 -104,-104 -56,56 104,104 -104,104 56,56ZM280,840q-33,0 -56.5,-23.5T200,760v-520h-40v-80h200v-40h240v40h200v80h-40v520q0,33 -23.5,56.5T680,840L280,840ZM680,240L280,240v520h400v-520ZM280,240v520,-520Z"
+      android:fillColor="@android:color/black"/>
+</vector>

--- a/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
@@ -1,6 +1,11 @@
+import OSLog
+import SwiftData
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var shouldShowAlert = false
+    
     var body: some View {
         NavigationStack {
             VStack(spacing: 20) {
@@ -13,13 +18,58 @@ struct ContentView: View {
                 )
 
                 NavigationLink(
-                    destination: EventLogsView(),
+                    destination:
+                    EventLogsView()
+                        .toolbar {
+                            ToolbarItem(placement: .topBarTrailing) {
+                                Button {
+                                    showAlert()
+                                } label: {
+                                    Image(systemName: "trash")
+                                }
+                            }
+                        },
                     label: {
                         Text("View Event Logs")
                     }
                 )
             }
             .padding()
+            .alert(isPresented: $shouldShowAlert) {
+                Alert(
+                    title: Text("Delete all events logs"),
+                    message: Text("Are you sure you want to remove all the practice and actual trial event log data?"),
+                    primaryButton: .destructive(Text("Delete")) {
+                        removeAllEventLogs()
+                    },
+                    secondaryButton: .cancel {}
+                )
+            }
+        }
+    }
+    
+    private func showAlert() {
+        shouldShowAlert = true
+    }
+    
+    private func removeAllEventLogs() {
+        let practiceEvents = try? modelContext.fetch(FetchDescriptor<PracticeTaskResult>())
+        let actualEvents = try? modelContext.fetch(FetchDescriptor<TaskResult>())
+        
+        guard let practiceEvents, let actualEvents else { return }
+        
+        practiceEvents.forEach { practiceEvent in
+            modelContext.delete(practiceEvent)
+        }
+        
+        actualEvents.forEach { trialData in
+            modelContext.delete(trialData)
+        }
+        
+        do {
+            try modelContext.save()
+        } catch {
+            os_log(.error, "Error saving modelContext after deletion: \(error)")
         }
     }
 }

--- a/public/js/elements/message.js
+++ b/public/js/elements/message.js
@@ -1,0 +1,26 @@
+export default class Message {
+    constructor(scene, gameWidth, backgroundColor, borderColor, messageText, messageTextColor, height, yPosition, xOffset, yOffset) {
+        this.feedbackBg = scene.add.graphics();
+        this.feedbackBg.fillStyle(backgroundColor, 1);
+        this.feedbackBg.lineStyle(2, borderColor, 1);
+    
+        const padding = { x: 20, y: 10 };
+        const width = gameWidth * 0.8;
+  
+        this.feedbackBg.fillRoundedRect((gameWidth - width)/2 + xOffset, yPosition - height, width, height, 10);
+        this.feedbackBg.strokeRoundedRect((gameWidth - width)/2 + xOffset, yPosition - height, width, height, 10);
+  
+        this.feedback = scene.add.text(gameWidth/2 + xOffset, yPosition + yOffset, messageText, {
+            font: "16px monospace",
+            fill: messageTextColor,
+            align: 'center',
+            padding: padding
+        }).setOrigin(0.5, 1);
+
+        this.destroy = function() {
+            this.feedback.destroy();
+            this.feedbackBg.destroy();
+        }
+    }
+}
+  

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -44,6 +44,7 @@ var trialEffort;
 var nCoins = 0; 
 var feedback;
 var feedbackTime = 1000;
+var animationTime = 400;
 var blockNo = 0;
 var trialsPerBlock;
 // initialize timing and response vars
@@ -450,10 +451,10 @@ var effortOutcome = function() {
             targets: feedback,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
-            ease: 'Back',    
-            duration: feedbackTime,
+            ease: 'Linear',    
+            duration: animationTime,
             repeat: 0,      
-            yoyo: true
+            yoyo: false
         });
 
         // then player floats across 'high route' and collects coins
@@ -503,10 +504,10 @@ var effortOutcome = function() {
             targets: feedback,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
-            ease: 'Back',    
-            duration: feedbackTime,
+            ease: 'Linear',    
+            duration: animationTime,
             repeat: 0,      
-            yoyo: true
+            yoyo: false
         });
 
         // then player floats across 'low route' and collects coins
@@ -554,10 +555,10 @@ var effortOutcome = function() {
             targets: feedback,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
-            ease: 'Back',    
-            duration: feedbackTime,
+            ease: 'Linear',    
+            duration: animationTime,
             repeat: 0,      
-            yoyo: true
+            yoyo: false
         });
         // then play powerup fail anim and progress via slow route
         this.time.addEvent({delay: feedbackTime+250, 
@@ -606,10 +607,10 @@ var effortOutcome = function() {
             targets: feedback,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
-            ease: 'Back',    
-            duration: feedbackTime,
+            ease: 'Linear',    
+            duration: animationTime,
             repeat: 0,      
-            yoyo: true
+            yoyo: false
         });
         // then play powerup fail anim and progress via slow route
         this.time.addEvent({delay: feedbackTime+250, 

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -18,6 +18,8 @@ import {sceneOrder, runPractice, effortTime, nBlocks, nCalibrates,
     trialsFile, nTrials, catchIdx, minPressMax, thresholdAutoSet, debug_mode
 } from "../versionInfo.js";
 
+import Message from "../elements/message.js";
+
 // make sure that the scene order is evaluated
 //const evaluatedSceneOrder = sceneOrder.map(sceneName => eval(sceneName));
 
@@ -42,7 +44,7 @@ var trialEffort2;
 var trialEffortPropChosen
 var trialEffort;
 var nCoins = 0; 
-var feedback;
+var feedbackMessage;
 var feedbackTime = 1000;
 var animationTime = 400;
 var blockNo = 0;
@@ -424,31 +426,20 @@ var effortOutcome = function() {
         // add overlap colliders so coins disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.coins1.sprite, collectCoins, null, this); 
         // display success message for a couple of seconds,
-        const feedbackBg = this.add.graphics();
-        feedbackBg.fillStyle(0xBCF3D4, 1);
-        feedbackBg.lineStyle(2, 0x25D070, 1);
-        
-        // calculate the text width and height with padding
-        const padding = { x: 20, y: 10 };
-        const width = gameWidth * 0.8;  // 80% of screen width
-        const height = 40;
-        const yPosition = 100;
-        
-        // draw the rounded rectangle background centered on screen
-        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
-        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
-        
-        // add text on top of the background
-        feedback = this.add.text(gameWidth/2 + 80, yPosition,  
-                                 "Nice work!", {
-                                    font: "16px monospace",
-                                    fill: "#10562F",
-                                    align: 'center',
-                                    padding: padding
-                                 })
-            .setOrigin(0.5, 1);
+        this.feedbackMessage = new Message(
+            this,
+            gameWidth,
+            0xBCF3D4,
+            0x25D070,
+            "Nice work!",
+            "#10562F",
+            40,
+            100,
+            80,
+            0
+        );
         this.tweens.add({        
-            targets: feedback,
+            targets: this.feedbackMessage,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
             ease: 'Linear',    
@@ -460,8 +451,7 @@ var effortOutcome = function() {
         // then player floats across 'high route' and collects coins
         this.time.addEvent({delay: feedbackTime, 
                             callback: function(){
-                                feedback.destroy();
-                                feedbackBg.destroy();  // Add this line to destroy the background
+                                this.feedbackMessage.destroy();
                                 this.player.sprite.anims.play('float', true);    
                                 this.player.sprite.setVelocityX(playerVelocity/3);
                                 this.time.addEvent({ delay: 120,
@@ -476,32 +466,22 @@ var effortOutcome = function() {
         trialSuccess = 1;
         // add overlap colliders so coins disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.coins2.sprite, collectCoins, null, this, trialNo); 
+
         // display success message for a couple of seconds,
-        const feedbackBg = this.add.graphics();
-        feedbackBg.fillStyle(0xBCF3D4, 1);
-        feedbackBg.lineStyle(2, 0x25D070, 1);
-        
-        // Calculate the text width and height with padding
-        const padding = { x: 20, y: 10 };
-        const width = gameWidth * 0.8;  // 80% of screen width
-        const height = 40;     
-        const yPosition = 100;
-        
-        // draw the rounded rectangle background centered on screen
-        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
-        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
-        
-        // add text on top of the background
-        feedback = this.add.text(gameWidth/2 + 80, yPosition,  
-                                 "Nice work!", {
-                                    font: "16px monospace",
-                                    fill: "#10562F",
-                                    align: 'center',
-                                    padding: padding
-                                 })
-            .setOrigin(0.5, 1);
+        this.feedbackMessage = new Message(
+            this,
+            gameWidth,
+            0xBCF3D4,
+            0x25D070,
+            "Nice work!",
+            "#10562F",
+            40,
+            100,
+            80,
+            0
+        );
         this.tweens.add({        
-            targets: feedback,
+            targets: this.feedbackMessage,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
             ease: 'Linear',    
@@ -512,9 +492,8 @@ var effortOutcome = function() {
 
         // then player floats across 'low route' and collects coins
         this.time.addEvent({delay: feedbackTime, 
-                            callback: function(){
-                                feedback.destroy();
-                                feedbackBg.destroy();
+                            callback: function() {
+                                this.feedbackMessage.destroy();
                                 this.player.sprite.anims.play('float', true);    
                                 this.player.sprite.setVelocityX(playerVelocity/3);
                                 this.time.addEvent({ delay: 100,
@@ -528,31 +507,20 @@ var effortOutcome = function() {
         trialSuccess = 0;
 
         // display failure message for a couple of seconds
-        const feedbackBg = this.add.graphics();
-        feedbackBg.fillStyle(0xFFDBDB, 1);
-        feedbackBg.lineStyle(2, 0xFF9696, 1);
-        
-        // calculate the text width and height with padding
-        const padding = { x: 20, y: 10 };
-        const width = gameWidth * 0.8;  // 80% of screen width
-        const height = 60;
-        const yPosition = 140;
-        
-        // draw rounded rectangle background centered on screen
-        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
-        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
-        
-        // add text on top of the background
-        feedback = this.add.text(gameWidth/2 + 80, yPosition,  
-                                 "Too slow - you only have 5\nseconds to choose a route", {
-                                    font: "16px monospace",
-                                    fill: "#9B0000",
-                                    align: 'center',
-                                    padding: padding
-                                 })
-            .setOrigin(0.5, 1);
+        this.feedbackMessage = new Message(
+            this,
+            gameWidth,
+            0xFFDBDB,
+            0xFF9696,
+            "Too slow - you only have 5\nseconds to choose a route",
+            "#9B0000",
+            60,
+            140,
+            80,
+            0
+        );
         this.tweens.add({        
-            targets: feedback,
+            targets: this.feedbackMessage,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
             ease: 'Linear',    
@@ -562,9 +530,8 @@ var effortOutcome = function() {
         });
         // then play powerup fail anim and progress via slow route
         this.time.addEvent({delay: feedbackTime+250, 
-                            callback: function(){
-                                feedback.destroy();
-                                feedbackBg.destroy();  // Add this line to destroy the background
+                            callback: function() {
+                                this.feedbackMessage.destroy();  // Add this line to destroy the background
                                 // then play short 'powerup fail' anim:
                                 // this.player.sprite.anims.play('powerupfail', true);
                                 // and progress via bridge route (with sad face)
@@ -580,31 +547,20 @@ var effortOutcome = function() {
     } else {  // else if fail to reach trial effort threshold
         trialSuccess = 0;
         // display failure message for a couple of seconds
-        const feedbackBg = this.add.graphics();
-        feedbackBg.fillStyle(0xFFDBDB, 1);
-        feedbackBg.lineStyle(2, 0xFF9696, 1);
-        
-        // Calculate the text width and height with padding
-        const padding = { x: 20, y: 10 };
-        const width = gameWidth * 0.8;  // 80% of screen width
-        const height = 40;        
-        const yPosition = 100;
-        
-        // draw rounded rectangle background centered on screen
-        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
-        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
-        
-        // add text on top of the background
-        feedback = this.add.text(gameWidth/2 + 80, yPosition,  
-                                 "Not enough power this time!", {
-                                    font: "16px monospace",
-                                    fill: "#9B0000",
-                                    align: 'center',
-                                    padding: padding
-                                 })
-            .setOrigin(0.5, 1);
+        this.feedbackMessage = new Message(
+            this,
+            gameWidth,
+            0xFFDBDB,
+            0xFF9696,
+            "Not enough power this time!",
+            "#9B0000",
+            40,
+            100,
+            80,
+            0
+        );
         this.tweens.add({        
-            targets: feedback,
+            targets: this.feedbackMessage,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
             ease: 'Linear',    
@@ -614,9 +570,8 @@ var effortOutcome = function() {
         });
         // then play powerup fail anim and progress via slow route
         this.time.addEvent({delay: feedbackTime+250, 
-                            callback: function(){
-                                feedback.destroy();
-                                feedbackBg.destroy();
+                            callback: function() {
+                                this.feedbackMessage.destroy();
                                 // then play short 'powerup fail' anim:
                                 this.player.sprite.anims.play('powerupfail', true);
                                 // and progress via bridge route (with sad face)

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -423,13 +423,27 @@ var effortOutcome = function() {
         // add overlap colliders so coins disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.coins1.sprite, collectCoins, null, this); 
         // display success message for a couple of seconds,
-        feedback = this.add.text(decisionPointX-20, gameHeight/2-160,  
+        const feedbackBg = this.add.graphics();
+        feedbackBg.fillStyle(0xBCF3D4, 1);
+        feedbackBg.lineStyle(2, 0x25D070, 1);
+        
+        // calculate the text width and height with padding
+        const padding = { x: 20, y: 10 };
+        const width = gameWidth * 0.8;  // 80% of screen width
+        const height = 40;
+        const yPosition = 100;
+        
+        // draw the rounded rectangle background centered on screen
+        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
+        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
+        
+        // add text on top of the background
+        feedback = this.add.text(gameWidth/2 + 80, yPosition,  
                                  "Nice work!", {
-                                    font: "20px monospace",
-                                    fill: "#ffffff",
+                                    font: "16px monospace",
+                                    fill: "#10562F",
                                     align: 'center',
-                                    padding: { x: 20, y: 10 },
-                                    backgroundColor: "#1ea7e1"
+                                    padding: padding
                                  })
             .setOrigin(0.5, 1);
         this.tweens.add({        
@@ -441,10 +455,12 @@ var effortOutcome = function() {
             repeat: 0,      
             yoyo: true
         });
+
         // then player floats across 'high route' and collects coins
         this.time.addEvent({delay: feedbackTime, 
                             callback: function(){
                                 feedback.destroy();
+                                feedbackBg.destroy();  // Add this line to destroy the background
                                 this.player.sprite.anims.play('float', true);    
                                 this.player.sprite.setVelocityX(playerVelocity/3);
                                 this.time.addEvent({ delay: 120,
@@ -460,13 +476,27 @@ var effortOutcome = function() {
         // add overlap colliders so coins disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.coins2.sprite, collectCoins, null, this, trialNo); 
         // display success message for a couple of seconds,
-        feedback = this.add.text(decisionPointX-20, gameHeight/2-160,  
+        const feedbackBg = this.add.graphics();
+        feedbackBg.fillStyle(0xBCF3D4, 1);
+        feedbackBg.lineStyle(2, 0x25D070, 1);
+        
+        // Calculate the text width and height with padding
+        const padding = { x: 20, y: 10 };
+        const width = gameWidth * 0.8;  // 80% of screen width
+        const height = 40;     
+        const yPosition = 100;
+        
+        // draw the rounded rectangle background centered on screen
+        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
+        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
+        
+        // add text on top of the background
+        feedback = this.add.text(gameWidth/2 + 80, yPosition,  
                                  "Nice work!", {
-                                    font: "20px monospace",
-                                    fill: "#ffffff",
+                                    font: "16px monospace",
+                                    fill: "#10562F",
                                     align: 'center',
-                                    padding: { x: 20, y: 10 },
-                                    backgroundColor: "#1ea7e1"
+                                    padding: padding
                                  })
             .setOrigin(0.5, 1);
         this.tweens.add({        
@@ -478,10 +508,12 @@ var effortOutcome = function() {
             repeat: 0,      
             yoyo: true
         });
+
         // then player floats across 'low route' and collects coins
         this.time.addEvent({delay: feedbackTime, 
                             callback: function(){
                                 feedback.destroy();
+                                feedbackBg.destroy();
                                 this.player.sprite.anims.play('float', true);    
                                 this.player.sprite.setVelocityX(playerVelocity/3);
                                 this.time.addEvent({ delay: 100,
@@ -495,13 +527,27 @@ var effortOutcome = function() {
         trialSuccess = 0;
 
         // display failure message for a couple of seconds
-        feedback = this.add.text(decisionPointX-60, gameHeight/2-160,  
-                                 "Ran out of time to decide!", {
-                                    font: "20px monospace",
-                                    fill: "#ffffff",
+        const feedbackBg = this.add.graphics();
+        feedbackBg.fillStyle(0xFFDBDB, 1);
+        feedbackBg.lineStyle(2, 0xFF9696, 1);
+        
+        // calculate the text width and height with padding
+        const padding = { x: 20, y: 10 };
+        const width = gameWidth * 0.8;  // 80% of screen width
+        const height = 60;
+        const yPosition = 140;
+        
+        // draw rounded rectangle background centered on screen
+        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
+        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
+        
+        // add text on top of the background
+        feedback = this.add.text(gameWidth/2 + 80, yPosition,  
+                                 "Too slow - you only have 5\nseconds to choose a route", {
+                                    font: "16px monospace",
+                                    fill: "#9B0000",
                                     align: 'center',
-                                    padding: { x: 20, y: 10 },
-                                    backgroundColor: "#000000"
+                                    padding: padding
                                  })
             .setOrigin(0.5, 1);
         this.tweens.add({        
@@ -517,6 +563,7 @@ var effortOutcome = function() {
         this.time.addEvent({delay: feedbackTime+250, 
                             callback: function(){
                                 feedback.destroy();
+                                feedbackBg.destroy();  // Add this line to destroy the background
                                 // then play short 'powerup fail' anim:
                                 // this.player.sprite.anims.play('powerupfail', true);
                                 // and progress via bridge route (with sad face)
@@ -532,13 +579,27 @@ var effortOutcome = function() {
     } else {  // else if fail to reach trial effort threshold
         trialSuccess = 0;
         // display failure message for a couple of seconds
-        feedback = this.add.text(decisionPointX-20, gameHeight/2-160,  
-                                 "Not enough\npower this time!", {
-                                    font: "20px monospace",
-                                    fill: "#ffffff",
+        const feedbackBg = this.add.graphics();
+        feedbackBg.fillStyle(0xFFDBDB, 1);
+        feedbackBg.lineStyle(2, 0xFF9696, 1);
+        
+        // Calculate the text width and height with padding
+        const padding = { x: 20, y: 10 };
+        const width = gameWidth * 0.8;  // 80% of screen width
+        const height = 40;        
+        const yPosition = 100;
+        
+        // draw rounded rectangle background centered on screen
+        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
+        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 80, yPosition - height, width, height, 10);
+        
+        // add text on top of the background
+        feedback = this.add.text(gameWidth/2 + 80, yPosition,  
+                                 "Not enough power this time!", {
+                                    font: "16px monospace",
+                                    fill: "#9B0000",
                                     align: 'center',
-                                    padding: { x: 20, y: 10 },
-                                    backgroundColor: "#000000"
+                                    padding: padding
                                  })
             .setOrigin(0.5, 1);
         this.tweens.add({        
@@ -554,6 +615,7 @@ var effortOutcome = function() {
         this.time.addEvent({delay: feedbackTime+250, 
                             callback: function(){
                                 feedback.destroy();
+                                feedbackBg.destroy();
                                 // then play short 'powerup fail' anim:
                                 this.player.sprite.anims.play('powerupfail', true);
                                 // and progress via bridge route (with sad face)

--- a/public/js/scenes/practiceTask.js
+++ b/public/js/scenes/practiceTask.js
@@ -284,7 +284,7 @@ var effortOutcome = function() {
         
         // add text on top of the background container
         feedback = this.add.text(gameWidth/2 + 120, yPosition - 5,  
-                                 "<b>Great effort!</b>\nLet's try again\npractice makes perfect.", {
+                                 "Great effort!\nLet's try again\npractice makes perfect.", {
                                     font: "16px monospace",
                                     fill: "#000000",
                                     align: 'center',

--- a/public/js/scenes/practiceTask.js
+++ b/public/js/scenes/practiceTask.js
@@ -33,7 +33,6 @@ var nPracTrials = pracTrialRewards.length;
 var pracTrialReward;
 var pracTrialEffort;
 var gemHeight;
-var gemText;
 var feedback;
 var pressCount;
 var pressTimes;
@@ -143,15 +142,6 @@ export default class PracticeTask extends Phaser.Scene {
         //                backgroundColor: "#1ea7e1"
         //            })
         //            .setScrollFactor(0);
-        // add coin count text in a fixed position on the screen
-        gemText = this.add
-            .text(gameWidth - 160, 16, "gems: " + nGems, {
-                font: "18px monospace",
-                fill: "#fc94c4",
-                padding: { x: 20, y: 10 },
-                backgroundColor: "#000000"
-            })
-            .setScrollFactor(0);
 
         /////////////UI: CHOICES AND RATINGS///////////////
         // UI functionality built using Rex UI plugins for phaser3 
@@ -384,8 +374,7 @@ var pracTrialEnd = function () {
 //////////////////////MISC FUNCTIONS/////////////////////
 // function to make coin sprites disappear upon contact with player
 // (so player appears to 'collect' them)
-var collectGems = function(player, gem){
+var collectGems = function(player, gem) {
     gem.disableBody(true, true);      // individual gems from physics group become invisible upon overlap
     nGems++; 
-    gemText.setText('gems: '+nGems);  // and gems total and text updates
 };

--- a/public/js/scenes/practiceTask.js
+++ b/public/js/scenes/practiceTask.js
@@ -13,6 +13,8 @@ import eventsCenter from '../eventsCenter.js'
 // import effort info from versionInfo file
 import { effortTime, pracTrialEfforts, gemHeights, pracTrialRewards } from "../versionInfo.js";
 
+import Message from "../elements/message.js";
+
 // // import some js from Pavlovia lib to enable data saving [for Pavlovia deployment only]
 // import * as data from "../../lib/data-2020.2.js";
 // import { saveTrialDataPav } from '../saveData.js';
@@ -33,7 +35,7 @@ var nPracTrials = pracTrialRewards.length;
 var pracTrialReward;
 var pracTrialEffort;
 var gemHeight;
-var feedback;
+var feedbackMessage;
 var pressCount;
 var pressTimes;
 var trialSuccess;
@@ -268,32 +270,21 @@ var effortOutcome = function() {
         // add overlap colliders so coins  on either route disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.gems.sprite, collectGems, null, this); 
 
-        // create a graphics object for the background
-        const feedbackBg = this.add.graphics();
-        feedbackBg.fillStyle(0xF6F8F9, 1);
-        feedbackBg.lineStyle(2, 0xD0D5DD, 1);
-        
-        // calculate the text width and height with padding
-        const padding = { x: 20, y: 10 };
-        const width = gameWidth * 0.8;  // 80% of screen width
-        const height = 85;        
-        const yPosition = 160;
-        
-        // draw the rounded rectangle background container centered on screen
-        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
-        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
-        
-        // add text on top of the background container
-        feedback = this.add.text(gameWidth/2 + 120, yPosition - 5,  
-                                 "Great effort!\nLet's try again\npractice makes perfect.", {
-                                    font: "16px monospace",
-                                    fill: "#000000",
-                                    align: 'center',
-                                    padding: padding
-                                 })
-            .setOrigin(0.5, 1);
+        this.feedbackMessage = new Message(
+            this,
+            gameWidth,
+            0xF6F8F9,
+            0xD0D5DD,
+            "Great effort!\nLet's try again\npractice makes perfect.",
+            "#000000",
+            85,
+            160,
+            110,
+            -5
+          );
+          
         this.tweens.add({        
-            targets: feedback,
+            targets: this.feedbackMessage,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
             ease: 'Linear',    
@@ -304,8 +295,7 @@ var effortOutcome = function() {
         // then player floats across 'high route' and collects coins
         this.time.addEvent({delay: pracFeedbackTime+250, 
                             callback: function(){
-                                feedback.destroy();
-                                feedbackBg.destroy();
+                                this.feedbackMessage.destroy();
                                 this.player.sprite.anims.play('float', true);    
                                 this.player.sprite.setVelocityX(playerVelocity/3);
                                 this.time.addEvent({ delay: 150, 
@@ -318,31 +308,21 @@ var effortOutcome = function() {
     else {  // else if fail to reach trial effort threshold
         trialSuccess = 0;
         // display failure message for a couple of seconds
-        const feedbackBg = this.add.graphics();
-        feedbackBg.fillStyle(0xF6F8F9, 1);
-        feedbackBg.lineStyle(2, 0xD0D5DD, 1);
-        
-        // calculate the text width and height with padding
-        const padding = { x: 20, y: 10 };
-        const width = gameWidth * 0.85;  // 85% of screen width
-        const height = 60;
-        const yPosition = 130;
-        
-        // draw the rounded rectangle background container centered on screen
-        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
-        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
-        
-        // add text on top of the background container
-        feedback = this.add.text(gameWidth/2 + 120, yPosition - 10,  
-                                 "Not enough power this time!", {
-                                    font: "16px monospace",
-                                    fill: "#000000",
-                                    align: 'center',
-                                    padding: padding
-                                 })
-            .setOrigin(0.5, 1);
+        this.feedbackMessage = new Message(
+            this,
+            gameWidth,
+            0xF6F8F9,
+            0xD0D5DD,
+            "Not enough power this time!",
+            "#000000",
+            60,
+            130,
+            110,
+            -10
+        );
+
         this.tweens.add({        
-            targets: feedback,
+            targets: this.feedbackMessage,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
             ease: 'Linear',    
@@ -353,8 +333,7 @@ var effortOutcome = function() {
         // then play powerup fail anim and progress via slow route
         this.time.addEvent({delay: pracFeedbackTime+250, 
                             callback: function(){
-                                feedback.destroy();
-                                feedbackBg.destroy();
+                                this.feedbackMessage.destroy();
                                 // then play short 'powerup fail' anim:
                                 this.player.sprite.anims.play('powerupfail', true);
                                 // and progress via bridge route (with sad face)

--- a/public/js/scenes/practiceTask.js
+++ b/public/js/scenes/practiceTask.js
@@ -40,6 +40,7 @@ var trialSuccess;
 var maxPressCount;
 // initiliaze timing and response vars
 var pracFeedbackTime = 1500;
+var pracAnimationTime = 400;
 const practiceOrReal = 0;
 
 // this function extends Phaser.Scene and includes the core logic for the game
@@ -295,10 +296,10 @@ var effortOutcome = function() {
             targets: feedback,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
-            ease: 'Back',    
-            duration: pracFeedbackTime,
+            ease: 'Linear',    
+            duration: pracAnimationTime,
             repeat: 0,      
-            yoyo: true
+            yoyo: false
         });
         // then player floats across 'high route' and collects coins
         this.time.addEvent({delay: pracFeedbackTime+250, 
@@ -332,7 +333,7 @@ var effortOutcome = function() {
         feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
         
         // add text on top of the background container
-        feedback = this.add.text(gameWidth/2 + 120, yPosition - 5,  
+        feedback = this.add.text(gameWidth/2 + 120, yPosition - 10,  
                                  "Not enough power this time!", {
                                     font: "16px monospace",
                                     fill: "#000000",
@@ -344,10 +345,10 @@ var effortOutcome = function() {
             targets: feedback,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
-            ease: 'Back',    
-            duration: pracFeedbackTime,
+            ease: 'Linear',    
+            duration: pracAnimationTime,
             repeat: 0,      
-            yoyo: true
+            yoyo: false
         });
         // then play powerup fail anim and progress via slow route
         this.time.addEvent({delay: pracFeedbackTime+250, 

--- a/public/js/scenes/practiceTask.js
+++ b/public/js/scenes/practiceTask.js
@@ -266,14 +266,29 @@ var effortOutcome = function() {
         trialSuccess = 1;
         // add overlap colliders so coins  on either route disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.gems.sprite, collectGems, null, this); 
-        // display success message for a couple of seconds,
-        feedback = this.add.text(decisionPointX, gameHeight/2-100,  
-                                 "Nice work!", {
-                                    font: "22px monospace",
-                                    fill: "#ffffff",
+
+        // create a graphics object for the background
+        const feedbackBg = this.add.graphics();
+        feedbackBg.fillStyle(0xF6F8F9, 1);
+        feedbackBg.lineStyle(2, 0xD0D5DD, 1);
+        
+        // calculate the text width and height with padding
+        const padding = { x: 20, y: 10 };
+        const width = gameWidth * 0.8;  // 80% of screen width
+        const height = 85;        
+        const yPosition = 160;
+        
+        // draw the rounded rectangle background container centered on screen
+        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
+        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
+        
+        // add text on top of the background container
+        feedback = this.add.text(gameWidth/2 + 120, yPosition - 5,  
+                                 "<b>Great effort!</b>\nLet's try again\npractice makes perfect.", {
+                                    font: "16px monospace",
+                                    fill: "#000000",
                                     align: 'center',
-                                    padding: { x: 20, y: 10 },
-                                    backgroundColor: "#1ea7e1"
+                                    padding: padding
                                  })
             .setOrigin(0.5, 1);
         this.tweens.add({        
@@ -289,6 +304,7 @@ var effortOutcome = function() {
         this.time.addEvent({delay: pracFeedbackTime+250, 
                             callback: function(){
                                 feedback.destroy();
+                                feedbackBg.destroy();
                                 this.player.sprite.anims.play('float', true);    
                                 this.player.sprite.setVelocityX(playerVelocity/3);
                                 this.time.addEvent({ delay: 150, 
@@ -301,13 +317,27 @@ var effortOutcome = function() {
     else {  // else if fail to reach trial effort threshold
         trialSuccess = 0;
         // display failure message for a couple of seconds
-        feedback = this.add.text(decisionPointX, gameHeight/2-100,  
-                                 "Not enough\npower this time!", {
-                                    font: "22px monospace",
-                                    fill: "#ffffff",
+        const feedbackBg = this.add.graphics();
+        feedbackBg.fillStyle(0xF6F8F9, 1);
+        feedbackBg.lineStyle(2, 0xD0D5DD, 1);
+        
+        // calculate the text width and height with padding
+        const padding = { x: 20, y: 10 };
+        const width = gameWidth * 0.85;  // 85% of screen width
+        const height = 60;
+        const yPosition = 130;
+        
+        // draw the rounded rectangle background container centered on screen
+        feedbackBg.fillRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
+        feedbackBg.strokeRoundedRect((gameWidth - width)/2 + 120, yPosition - height, width, height, 10);
+        
+        // add text on top of the background container
+        feedback = this.add.text(gameWidth/2 + 120, yPosition - 5,  
+                                 "Not enough power this time!", {
+                                    font: "16px monospace",
+                                    fill: "#000000",
                                     align: 'center',
-                                    padding: { x: 20, y: 10 },
-                                    backgroundColor: "#000000"
+                                    padding: padding
                                  })
             .setOrigin(0.5, 1);
         this.tweens.add({        
@@ -323,6 +353,7 @@ var effortOutcome = function() {
         this.time.addEvent({delay: pracFeedbackTime+250, 
                             callback: function(){
                                 feedback.destroy();
+                                feedbackBg.destroy();
                                 // then play short 'powerup fail' anim:
                                 this.player.sprite.anims.play('powerupfail', true);
                                 // and progress via bridge route (with sad face)


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2582

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Removed the on screen gem counter in the practice trials
- Added the ability to remove all the event logs stored in the apps
- Updated the dialogs to match the designs

## TODOs
<!--- If your PR is still a work-in-progress, add checkboxes to this section to indicate outstanding work to be done. -->
<!--- If not relevant, delete this section. -->
- [x] Update the `Nice work!` part of the practice text to be bold (might require a Phaser version bump to 3.50 to enable experimental apis) - Will complete in another ticket
- [x] Do we want the pulsing text animation or just static text?

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1) Enable practice mode if you haven't already in `versionInfo.js`
2) Run through the practice task, ensuring you successfully complete at least 1 practice trial run. Observe the dialogs, ensure they look alright
2) Run the the main trial and ensure the following messages under the following scenarios work as expected:
- timeout dialog
- run out of time to power up
- success for choice 1
- success for choice 2

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| practice failure | practice success | trial timeout | trial success | trial failure |
| --- | --- | --- | --- | --- |
| <img width="389" alt="image" src="https://github.com/user-attachments/assets/80d9178e-57a6-4a1b-b8c8-cda3d1a66369" /> | <img width="441" alt="image" src="https://github.com/user-attachments/assets/4a23cb86-7494-448f-8368-998feaa2aa89" /> | <img width="329" alt="image" src="https://github.com/user-attachments/assets/0044c14e-6eb6-4f67-b1c1-97c519b55a0f" /> | <img width="418" alt="image" src="https://github.com/user-attachments/assets/6bc02d1b-8359-4b85-b74c-505d7e7a3dbf" /> | <img width="419" alt="image" src="https://github.com/user-attachments/assets/d0e08f0d-b48e-4587-a76e-f066f2405d53" /> |


