### PR TITLE
Add progress bar to main task scene [CON-2583]

### DIFF
--- a/public/js/elements/progressBar.js
+++ b/public/js/elements/progressBar.js
@@ -1,0 +1,66 @@
+export default class ProgressBar extends Phaser.GameObjects.Container {
+    constructor(scene, x, y, width, segments, progress, config = {}) {
+        super(scene, x, y);
+
+        // Default configuration
+        this.config = {
+            height: 20,
+            padding: 2,
+            backgroundColor: 0xFDC4AD,
+            fillColor: 0xCA3E04,
+            cornerRadius: 5,
+            ...config
+        };
+        
+        this.width = width;
+        this.segments = segments;
+        this.segmentWidth = (width / segments) - config.padding;
+        
+        this.progressSegments = [];
+        this.createProgressBar(progress);
+        
+        // Add this container to the scene
+        scene.add.existing(this);
+    }
+    
+    createProgressBar(progress) {
+        // Create background segments
+        for (let i = 0; i < this.segments; i++) {
+            const x = (i === 0) ? 0 : i * this.segmentWidth;
+            const segment = this.scene.add.graphics({ x: x, y: 0 });
+
+            const fillColor = (i <= progress) ? this.config.fillColor : this.config.backgroundColor;
+            // Set fill style (with full opacity here, change alpha as needed)
+            segment.fillStyle(fillColor, 1);
+
+            var rectRadius = 0;
+            if (i === 0) {
+                rectRadius = {
+                    tl: this.config.cornerRadius,
+                    tr: 0,
+                    bl: this.config.cornerRadius,
+                    br: 0
+                }
+            } else if (i === this.segments - 1) {
+                rectRadius = {
+                    tl: 0,
+                    tr: this.config.cornerRadius,
+                    bl: 0,
+                    br: this.config.cornerRadius
+                }
+            }
+
+            // Draw rounded rect with custom per-corner radii
+            segment.fillRoundedRect(
+                0,
+                0,
+                this.segmentWidth - this.config.padding,
+                this.config.height,
+                rectRadius
+            );
+
+            this.progressSegments.push(segment);
+            this.add(segment);
+        }
+    }
+} 

--- a/public/js/elements/progressBar.js
+++ b/public/js/elements/progressBar.js
@@ -27,13 +27,14 @@ export default class ProgressBar extends Phaser.GameObjects.Container {
         // Create background segments
         for (let i = 0; i < this.segments; i++) {
             const x = (i === 0) ? 0 : i * this.segmentWidth;
+            // Place a graphics object at the x, y coordinates within the scene x, y coordinates set in the constructor
             const segment = this.scene.add.graphics({ x: x, y: 0 });
 
             const fillColor = (i <= progress) ? this.config.fillColor : this.config.backgroundColor;
-            // Set fill style (with full opacity here, change alpha as needed)
             segment.fillStyle(fillColor, 1);
 
-            var rectRadius = 0;
+            var rectRadius = 0; // no rounded corners
+            // Apply rounded corners to first and last segments
             if (i === 0) {
                 rectRadius = {
                     tl: this.config.cornerRadius,
@@ -50,10 +51,10 @@ export default class ProgressBar extends Phaser.GameObjects.Container {
                 }
             }
 
-            // Draw rounded rect with custom per-corner radii
+            // Draw a rounded rectangle within the graphics x, y coordinates
             segment.fillRoundedRect(
-                0,
-                0,
+                0, // x: 0 as it's determined by the graphics object's x, y coordinates
+                0, // y: 0 as it's determined by the graphics object's x, y coordinates
                 this.segmentWidth - this.config.padding,
                 this.config.height,
                 rectRadius

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -7,6 +7,7 @@ import ChoicePanel from "../elements/choicePanel.js";
 import TimerPanel from "../elements/timerPanelClicks.js";
 import BreakPanel from "../elements/takeABreak.js";
 import StaticObjects from "../elements/staticObjects.js";
+import ProgressBar from "../elements/progressBar.js";
 
 // import our custom events center for passsing info between scenes and relevant data saving function
 import eventsCenter from '../eventsCenter.js'
@@ -208,6 +209,16 @@ export default class MainTask extends Phaser.Scene {
         // set the boundaries of the world
         this.physics.world.bounds.width = mapWidth;
         this.physics.world.bounds.height = gameHeight;
+
+        //////////////ADD PROGRESS BAR////////////////////
+        // Create progress bar at the top of the screen with nBlocks segments
+        this.progressBar = new ProgressBar(this, 24, 20, 300, nBlocks, blockNo, {
+            height: 10,
+            padding: 4,
+            cornerRadius: 5
+        });
+        // Make it stay fixed on screen (not affected by camera)
+        this.progressBar.setScrollFactor(0);
 
         //////////////ADD PLAYER SPRITE////////////////////
         this.player = new Player(this, 0, 350); // (this, spawnPoint.x, spawnPoint.y);


### PR DESCRIPTION
## Why did you make these changes?

https://deakinuniversity.atlassian.net/browse/CON-2583

## What changes did you make?

Created a new `ProgressBar` ui element which using the Graphics from Phaser creates rounded rectangles at the necessary locations with rounded corners for the first and last segments.

Every time a user progresses to the next block the progress bar should increment by 1 segment.

## Screenshots

<img width="344" alt="image" src="https://github.com/user-attachments/assets/d64a7a5a-2ec8-4cce-bd38-1c929b5233d9" />
