### PR TITLE
Event listerner key renaming [CON-2597]

### DIFF
--- a/public/js/elements/CountdownPanel.js
+++ b/public/js/elements/CountdownPanel.js
@@ -1,11 +1,11 @@
 import eventsCenter from '../eventsCenter.js'
-import { timeout } from '../versionInfo.js'
 
 export default class CountdownPanel {
-    constructor(scene, x, y, duration = timeout) {
+    constructor(scene, x, y, duration, timeoutKey) {
         this.scene = scene;
         this.duration = duration;
-        this.timeLeft = duration;
+        this.timeLeft = duration; // start with the full duration to then countdown
+        this.timeoutKey = timeoutKey;
 
         // Background
         this.panel = scene.rexUI.add.roundRectangle(27.5, 0, 100, 30, 6, 0xF2F4F7);
@@ -94,10 +94,11 @@ export default class CountdownPanel {
     }
     
     onComplete() {
-        eventsCenter.emit('countdownComplete');
+        eventsCenter.emit(this.timeoutKey);
         this.destroy();
     }
 
+    // Stop the timer from running, but allow the countdown objects to remain visible on the screen
     removeTimer() {
         if (this.timer) {
             this.timer.remove();
@@ -105,6 +106,7 @@ export default class CountdownPanel {
         }
     }
 
+    // Stop the timer from running, and remove the countdown objects from the screen
     destroy() {
         this.removeTimer();
         this.container.destroy();

--- a/public/js/elements/PowerPanel.js
+++ b/public/js/elements/PowerPanel.js
@@ -3,6 +3,8 @@ import eventsCenter from "../eventsCenter.js";
 import PowerMeterBar from "./PowerMeterBar.js";
 
 const POWER_UP_TIMEOUT_KEY = 'powerUpTimeout';
+export const POWER_UP_COMPLETE_KEY = 'powerUpComplete';
+export const PRACTICE_POWER_UP_COMPLETE_KEY = 'practicePowerUpComplete';
 
 export default class PowerPanel {
     constructor(scene, x, y, width, height, timeLimit, rewardCoins, power, trialEffort, isPractice = false) {
@@ -176,9 +178,9 @@ export default class PowerPanel {
         this.scene.registry.set('pressCount', this.pressCount);
         this.scene.registry.set('pressTimes', this.pressTimes);
         if (this.isPractice) {
-            eventsCenter.emit('practicetimesup');
+            eventsCenter.emit(PRACTICE_POWER_UP_COMPLETE_KEY); // TODO: Not currently used by the practiceTask
         } else {
-            eventsCenter.emit('timesup');
+            eventsCenter.emit(POWER_UP_COMPLETE_KEY);
         }
         // Stop listening to this registered event
         eventsCenter.removeListener(POWER_UP_TIMEOUT_KEY);

--- a/public/js/elements/PowerPanel.js
+++ b/public/js/elements/PowerPanel.js
@@ -2,6 +2,8 @@ import CountdownPanel from "./CountdownPanel.js";
 import eventsCenter from "../eventsCenter.js";
 import PowerMeterBar from "./PowerMeterBar.js";
 
+const POWER_UP_TIMEOUT_KEY = 'powerUpTimeout';
+
 export default class PowerPanel {
     constructor(scene, x, y, width, height, timeLimit, rewardCoins, power, trialEffort, isPractice = false) {
         this.scene = scene;
@@ -38,7 +40,7 @@ export default class PowerPanel {
             color: '#000000'
         });
 
-        this.countdownPanel = new CountdownPanel(this.scene, 0, 0, 10000);
+        this.countdownPanel = new CountdownPanel(this.scene, 0, 0, 10000, POWER_UP_TIMEOUT_KEY);
         headerRow.add(titleText, { expand: true });
         headerRow.add(this.countdownPanel.container);
 
@@ -133,8 +135,8 @@ export default class PowerPanel {
                 }
                 // User has reached the goal
                 if (this.pressCount >= this.trialEffort) {
-                    this.countdownPanel?.removeTimer(); // immediately stop the timer
-                    this.onComplete();
+                    this.countdownPanel?.destroy(); // immediately stop and remove the timer
+                    this.onSuccess();
                 }
             })
             .on('pointerout', () => {
@@ -149,8 +151,8 @@ export default class PowerPanel {
         this.container.layout();
 
         // Ran out of time to reach the trialEffort
-        eventsCenter.once('countdownComplete', () => {
-            this.onComplete();
+        eventsCenter.once(POWER_UP_TIMEOUT_KEY, () => {
+            this.onTimeout();
         });
     }
 
@@ -158,6 +160,16 @@ export default class PowerPanel {
         this.pressCount++;
         this.pressTimes.push(Math.round(this.scene.time.now));
         this.powerMeter.updatePowerBar(this.pressCount, this.trialEffort);
+    }
+
+    onTimeout() {
+        this.onComplete();
+        this.destroy();
+    }
+
+    onSuccess() {
+        this.onComplete();
+        setTimeout(() => { this.destroy(); }, 200); // Keep the panel visible for a brief moment
     }
 
     onComplete() {
@@ -168,7 +180,8 @@ export default class PowerPanel {
         } else {
             eventsCenter.emit('timesup');
         }
-        setTimeout(() => { this.destroy(); }, 100); // Keep the panel visible for a brief moment
+        // Stop listening to this registered event
+        eventsCenter.removeListener(POWER_UP_TIMEOUT_KEY);
     }
 
     destroy() {

--- a/public/js/elements/RouteSelectorPanel.js
+++ b/public/js/elements/RouteSelectorPanel.js
@@ -1,6 +1,9 @@
 import eventsCenter from '../eventsCenter.js';
 import CountdownPanel from './CountdownPanel.js';
 import PowerMeterBar from './PowerMeterBar.js';
+import { timeout } from '../versionInfo.js'
+
+const ROUTE_TIMEOUT_KEY = 'routeTimeout';
 
 export default class RouteSelectorPanel {
     constructor(scene, x, y, width, height, route1Coins, route1Power, route2Coins, route2Power, onSelect) {
@@ -44,7 +47,7 @@ export default class RouteSelectorPanel {
             // TODO: Font family
         });
 
-        this.countdownPanel = new CountdownPanel(this.scene, 0, 0);
+        this.countdownPanel = new CountdownPanel(this.scene, 0, 0, timeout, ROUTE_TIMEOUT_KEY);
         titleRow.add(title, { expand: true });
         titleRow.add(this.countdownPanel.container);
 
@@ -64,7 +67,7 @@ export default class RouteSelectorPanel {
         this.container.layout();
 
         // React when the countdown timer has finished
-        eventsCenter.once('countdownComplete', () => {
+        eventsCenter.once(ROUTE_TIMEOUT_KEY, () => {
             setTimeout(() => {
                 this.onSelect?.('timeout');
                 this.destroy();
@@ -204,6 +207,8 @@ export default class RouteSelectorPanel {
     }
 
     destroy() {
+        // Stop listening to this registered event
+        eventsCenter.removeListener(ROUTE_TIMEOUT_KEY);
         // Stop the countdown timer
         this.countdownPanel?.destroy();
         // Remove containers from the screen

--- a/public/js/scenes/mainTask.js
+++ b/public/js/scenes/mainTask.js
@@ -20,6 +20,7 @@ import {sceneOrder, runPractice, effortTime, nBlocks, nCalibrates,
 
 import Message from "../elements/message.js";
 import PowerPanel from "../elements/PowerPanel.js";
+import { POWER_UP_COMPLETE_KEY } from "../elements/PowerPanel.js";
 
 // make sure that the scene order is evaluated
 //const evaluatedSceneOrder = sceneOrder.map(sceneName => eval(sceneName));
@@ -445,7 +446,7 @@ var doChoice = function () {
         // and play player 'power-up' animation
         this.player.sprite.anims.play('powerup', true);
         // until time limit reached:
-        eventsCenter.once('timesup', effortOutcome, this)
+        eventsCenter.once(POWER_UP_COMPLETE_KEY, effortOutcome, this)
         }
     else if (choice == 'route 2') {  // if participant chooses the low effort option
         // timer panel pops up  
@@ -453,11 +454,11 @@ var doChoice = function () {
         // and play player 'power-up' animation
         this.player.sprite.anims.play('powerup', true);
         // until time limit reached:
-        eventsCenter.once('timesup', effortOutcome, this)
+        eventsCenter.once(POWER_UP_COMPLETE_KEY, effortOutcome, this)
     } else { // user failed to make a choice before timeout
         // No TimerPanel to emit the timesup event, so we emit it manually so the 'this' context can be passed through
-        eventsCenter.once('timesup', effortOutcome, this);
-        eventsCenter.emit('timesup');
+        eventsCenter.once(POWER_UP_COMPLETE_KEY, effortOutcome, this);
+        eventsCenter.emit(POWER_UP_COMPLETE_KEY);
     }
 };
 


### PR DESCRIPTION
## Why did you make these changes?

https://deakinuniversity.atlassian.net/browse/CON-2597

## What changes did you make?

The keys for some of the listeners were the same between the route-choice and power-up panels, which may have been causing race conditions with the results. The `CountdownPanel` now accepts an additional parameter so that a unique key can be used for emit the timeout event. Now those two panels can subscribe to their own timeout event listeners.

Also changed the event listener key for the power-up completion event and made them constants that can be imported when needed.

## Testing

1. Test that the route selection/timeout is working as expected.
2. Test that the power-up completion/timeout is working.
3. We should no longer encounter any press counts exceeding the trial effort requirement.