### PR TITLE
Fix the message dialog formatting [CON-2602]

### DIFF
--- a/public/src/elements/message.js
+++ b/public/src/elements/message.js
@@ -1,22 +1,35 @@
 export default class Message {
-    constructor(scene, gameWidth, fontString, backgroundColor, borderColor, messageText, messageTextColor, height, yPosition, xOffset, yOffset) {
+    constructor(scene, gameWidth, fontString, backgroundColor, borderColor, messageText, messageTextColor, yPosition) {
         this.scene = scene;
         this.feedbackBg = scene.add.graphics();
         this.feedbackBg.fillStyle(backgroundColor, 1);
         this.feedbackBg.lineStyle(2, borderColor, 1);
     
-        const padding = { x: 20, y: 10 };
-        const width = gameWidth * 0.8;
+        const textXSpacing = 30;
+        const textPadding = { x: 0, y: 20 };
+        const cameraWidth = scene.cameras.main.width;
+        const currentX = scene.cameras.main.scrollX;
+        const containerWidth = gameWidth * 0.9;
+        const containerXPos = currentX + (cameraWidth * 0.05);
+        const wordWrapWidth = containerWidth - textXSpacing * 2
+        const textXPos = containerXPos + (containerWidth - wordWrapWidth) / 2;
   
-        this.feedbackBg.fillRoundedRect((gameWidth - width)/2 + xOffset, yPosition - height, width, height, 10);
-        this.feedbackBg.strokeRoundedRect((gameWidth - width)/2 + xOffset, yPosition - height, width, height, 10);
-  
-        this.feedback = scene.add.text(gameWidth/2 + xOffset, yPosition + yOffset, messageText, {
+        this.feedback = scene.add.text(textXPos, yPosition, messageText, {
             font: fontString,
             fill: messageTextColor,
             align: 'center',
-            padding: padding
-        }).setOrigin(0.5, 1);
+            wordWrap: {
+                width: wordWrapWidth,
+                useAdvancedWordWrapping: true
+            },
+            fixedWidth: wordWrapWidth,
+            padding: textPadding
+        });
+
+        let containerHeight = this.feedback.height
+
+        this.feedbackBg.fillRoundedRect(containerXPos, yPosition, containerWidth, containerHeight, 10);
+        this.feedbackBg.strokeRoundedRect(containerXPos, yPosition, containerWidth, containerHeight, 10);
 
         this.destroy = function() {
             this.feedback.destroy();

--- a/public/src/elements/message.js
+++ b/public/src/elements/message.js
@@ -14,14 +14,16 @@ export default class Message {
         const wordWrapWidth = containerWidth - textXSpacing * 2
         const textXPos = containerXPos + (containerWidth - wordWrapWidth) / 2;
   
-        this.feedback = scene.add.text(textXPos, yPosition, messageText, {
+        this.feedback = scene.rexUI.add.BBCodeText(textXPos, yPosition, messageText, {
+            fontSize: '14px',
             font: fontString,
             fill: messageTextColor,
             align: 'center',
-            wordWrap: {
+            wrap: {
+                mode: 'word',
                 width: wordWrapWidth,
-                useAdvancedWordWrapping: true
             },
+            lineSpacing: 2,
             fixedWidth: wordWrapWidth,
             padding: textPadding
         });

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -485,10 +485,7 @@ var effortOutcome = function() {
             0x25D070,
             "Nice work!",
             "#10562F",
-            40,
-            100,
-            80,
-            0
+            80
         );
         this.tweens.add({        
             targets: this.feedbackMessage,
@@ -528,10 +525,7 @@ var effortOutcome = function() {
             0x25D070,
             "Nice work!",
             "#10562F",
-            40,
-            100,
-            80,
-            0
+            80
         );
         this.tweens.add({        
             targets: this.feedbackMessage,
@@ -568,10 +562,7 @@ var effortOutcome = function() {
             0xFF9696,
             "Too slow - you only have 5\nseconds to choose a route",
             "#9B0000",
-            60,
-            140,
-            80,
-            0
+            80
         );
         this.tweens.add({        
             targets: this.feedbackMessage,
@@ -609,10 +600,7 @@ var effortOutcome = function() {
             0xFF9696,
             "Not enough power this time!",
             "#9B0000",
-            40,
-            100,
-            80,
-            0
+            80
         );
         this.tweens.add({        
             targets: this.feedbackMessage,

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -326,10 +326,10 @@ var displayInfoPanel = function () {
 
 var showMessageForCurrentPracticeTrial = function (context) {
     let messages = [
-        "First, let\'s learn how to fly!. Tap the button as fast as you can to help Pickle fly. Press \'ready\' to start'.",
-        "Great effort! Let's try again - practice makes perfect.",
-        "Nice! Now, let\'s learn about routes. Routes require different amounts of effort and offer different rewards.",
-        "Your turn! Choose the route you\'d prefer to take. You have 5 seconds.",
+        "[b]First, let\'s learn how to fly![/b]\nTap the button as fast as you can to help Pickle fly. Press \'ready\' to start.",
+        "[b]Great effort![/b]\nLet's try again - practice makes perfect.",
+        "[b]Nice! Now, let\'s learn about routes.[/b]\nRoutes require different amounts of effort and offer different rewards.",
+        "[b]Your turn![/b]\nChoose the route you\'d prefer to take. You have 5 seconds.",
     ]
 
     // remove feedback message from the screen if its still there
@@ -383,7 +383,7 @@ var pracRound3AdditionalDialog = function(context) {
         feedbackMessage = null;
     }
 
-    let messageTextForCurrentTrial = "Each round you\'ll have 5 seconds to choose a route. For now, let\'s try Route 1.";
+    let messageTextForCurrentTrial = "[b]Each round you\'ll have 5 seconds to choose a route.[/b]\nFor now, let\'s try Route 1.";
     feedbackMessage = new Message(
         context,
         gameWidth,

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -326,10 +326,10 @@ var displayInfoPanel = function () {
 
 var showMessageForCurrentPracticeTrial = function (context) {
     let messages = [
-        "First, let\'s learn how to fly!\nTap the button as fast as you can\nto help Pickle fly. Press \'ready\' to start'.",
-        "Great effort!\nLet's try again\npractice makes perfect.",
-        "Nice! Now, let\'s learn about routes.\nRoutes require different amounts of\neffort and offer different rewards.",
-        "Your turn!\nChoose the route you\'d prefer to take.\nYou have 5 seconds.",
+        "First, let\'s learn how to fly!. Tap the button as fast as you can to help Pickle fly. Press \'ready\' to start'.",
+        "Great effort! Let's try again - practice makes perfect.",
+        "Nice! Now, let\'s learn about routes. Routes require different amounts of effort and offer different rewards.",
+        "Your turn! Choose the route you\'d prefer to take. You have 5 seconds.",
     ]
 
     // remove feedback message from the screen if its still there
@@ -348,10 +348,7 @@ var showMessageForCurrentPracticeTrial = function (context) {
         0xD0D5DD,
         messageTextForCurrentTrial,
         "#000000",
-        85,
-        160,
-        110,
-        -5
+        80
     );
 
     context.tweens.add({        
@@ -386,7 +383,7 @@ var pracRound3AdditionalDialog = function(context) {
         feedbackMessage = null;
     }
 
-    let messageTextForCurrentTrial = "Each round you\'ll have 5 seconds\nto choose a route.\nFor now, let\'s try Route 1.";
+    let messageTextForCurrentTrial = "Each round you\'ll have 5 seconds to choose a route. For now, let\'s try Route 1.";
     feedbackMessage = new Message(
         context,
         gameWidth,
@@ -395,10 +392,7 @@ var pracRound3AdditionalDialog = function(context) {
         0xD0D5DD,
         messageTextForCurrentTrial,
         "#000000",
-        85,
-        160,
-        110,
-        -5
+        80
     );
 
     context.tweens.add({        
@@ -469,10 +463,7 @@ var effortOutcome = function() {
             0xFF9696,
             "Too slow - you only have 5\nseconds to choose a route",
             "#9B0000",
-            60,
-            130,
-            110,
-            0
+            80
         );
 
         this.tweens.add({        
@@ -527,10 +518,7 @@ var effortOutcome = function() {
             0x25D070,
             "Nice work!",
             "#10562F",
-            60,
-            130,
-            110,
-            -10
+            80
         );
           
         this.tweens.add({        
@@ -590,10 +578,7 @@ var effortOutcome = function() {
             0xFF9696,
             "Not enough power this time!",
             "#9B0000",
-            60,
-            130,
-            110,
-            -10
+            80
         );
 
         this.tweens.add({        


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2602

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Updated the Message dialog sizing and position to be dynamically determined
- Added the bold text to the practice trials

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run through the task, ensure the following:
- The practice task dialog messages appear normal
- The bolded sections are present
- The timeout/success/failure dialogs which appear in both the practice and main trials still appear as normal

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Practice trial 1 | practice trial 2 | practice trial 3 | practice trial 3 (2nd dialog) | practice trial 4 |
| --- | --- | --- | --- | --- |
| <img width="373" alt="image" src="https://github.com/user-attachments/assets/edc4818a-0722-4a30-8aaf-e51ac7cb20f2" /> | <img width="377" alt="image" src="https://github.com/user-attachments/assets/8bea06d0-689e-417a-af2c-65108285affc" /> | <img width="374" alt="image" src="https://github.com/user-attachments/assets/7039fac6-1d97-4b60-a0a3-3c40ac611b08" /> | <img width="371" alt="image" src="https://github.com/user-attachments/assets/9c8cc248-13f3-4549-8ecb-2d95b0b9f112" /> | <img width="374" alt="image" src="https://github.com/user-attachments/assets/c5645a42-0883-43fe-9e01-9113441e54ec" /> |




