### PR TITLE
Disable the Route 2 option for the 3rd practice trial [CON-2603]

### DIFF
--- a/public/src/elements/RouteSelectorPanel.js
+++ b/public/src/elements/RouteSelectorPanel.js
@@ -68,16 +68,16 @@ export default class RouteSelectorPanel {
         this.container.layout();
 
         if (timeoutMillis == null) {
-            let overlay = this.scene.add.graphics();
+            this.overlay = this.scene.add.graphics();
 
             // for whatever reason the layout engine reports the route 2 x and y values as the centre point of the panel, adjust it so it actually covers the whole choice panel
             let overlayX = route2.x - (route2.width / 2);
             let overlayY = route2.y - (route2.height / 2);
 
-            overlay.fillStyle(0x000000, 0.25);
-            overlay.fillRoundedRect(overlayX, overlayY, route2.width, route2.height, 10);
-            overlay.lineStyle(5, 0x000000, 0.25);
-            overlay.fillStyle(0x000000, 0.25);
+            this.overlay.fillStyle(0x000000, 0.25);
+            this.overlay.fillRoundedRect(overlayX, overlayY, route2.width, route2.height, 10);
+            this.overlay.lineStyle(5, 0x000000, 0.25);
+            this.overlay.fillStyle(0x000000, 0.25);
         }
 
         // React when the countdown timer has finished
@@ -230,5 +230,6 @@ export default class RouteSelectorPanel {
         // Remove containers from the screen
         this.panel?.destroy();
         this.container?.destroy();
+        this.overlay?.destroy();
     }
 }

--- a/public/src/elements/RouteSelectorPanel.js
+++ b/public/src/elements/RouteSelectorPanel.js
@@ -57,8 +57,8 @@ export default class RouteSelectorPanel {
         // Buttons
         const optionsRow = scene.rexUI.add.sizer({ orientation: 'horizontal', space: { item: 20 } });
 
-        const route1 = this.createRouteButton('Route 1', this.route1Power, this.route1Coins);
-        const route2 = this.createRouteButton('Route 2', this.route2Power, this.route2Coins);
+        const route1 = this.createRouteButton('Route 1', this.route1Power, this.route1Coins, false);
+        const route2 = this.createRouteButton('Route 2', this.route2Power, this.route2Coins, timeoutMillis == null); // only show this one as disabled on the 3rd pracice round where we dont have a timeout defined
 
         optionsRow.add(route1, { expand: true });
         optionsRow.add(route2, { expand: true });
@@ -66,6 +66,19 @@ export default class RouteSelectorPanel {
         this.container.add(optionsRow, { expand: true });
 
         this.container.layout();
+
+        if (timeoutMillis == null) {
+            let overlay = this.scene.add.graphics();
+
+            // for whatever reason the layout engine reports the route 2 x and y values as the centre point of the panel, adjust it so it actually covers the whole choice panel
+            let overlayX = route2.x - (route2.width / 2);
+            let overlayY = route2.y - (route2.height / 2);
+
+            overlay.fillStyle(0x000000, 0.25);
+            overlay.fillRoundedRect(overlayX, overlayY, route2.width, route2.height, 10);
+            overlay.lineStyle(5, 0x000000, 0.25);
+            overlay.fillStyle(0x000000, 0.25);
+        }
 
         // React when the countdown timer has finished
         eventsCenter.once(ROUTE_TIMEOUT_KEY, () => {
@@ -76,7 +89,7 @@ export default class RouteSelectorPanel {
         });
     }
 
-    createRouteButton(routeName, power, reward) {
+    createRouteButton(routeName, power, reward, isDisabled) {
         const bg = this.scene.rexUI.add.roundRectangle(0, 0, 0, 0, 10, 0xFFFFFF).setStrokeStyle(2, 0xD64204);
 
         const sizer = this.scene.rexUI.add.overlapSizer({
@@ -166,7 +179,8 @@ export default class RouteSelectorPanel {
         sizer.addBackground(bg);
         sizer.add(buttonSizer, { align: 'center' });
 
-        sizer.setInteractive()
+        if (!isDisabled) {
+            sizer.setInteractive()
             // User has dragged/touched their cursor/finger over/onto the button
             .on('pointerover', () => {
                 this.clearSelections();
@@ -183,6 +197,7 @@ export default class RouteSelectorPanel {
                 this.destroy();
             });
 
+        }
         // Keep track to reset background color
         sizer.__bg__ = bg;
 


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2603

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
Greyed out the 2nd choice panel in the 3rd practice trial so the user is forced to go down the 1st option route

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## Notes
- This PR just forces the user to go down the route 1 route using a greyed out option 2. If we decide we want to use the blur effect like in the designs that will need to addressed in another PR.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1) Enable practice mode in `versionInfo.js` if you havent already
2) Progress through the practice trials untill you reach trial 3
3) See the new disabled behaviour for the 3rd practice trial, confirm you cannot press option 2 at all.
4) Run the last practice trial and get to the main trials, ensure the route selector works for the main trials as well

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
<img width="405" alt="image" src="https://github.com/user-attachments/assets/626461d5-485f-4bdb-a212-f47694e03bbe" />
