### PR TITLE
Update the progress bar to show sub-progress in the block [CON-2613]

### DIFF
--- a/public/src/elements/progressBar.js
+++ b/public/src/elements/progressBar.js
@@ -16,7 +16,7 @@ export default class ProgressBar extends Phaser.GameObjects.Container {
         const closeBtnWidth = 55;
         this.width = window.innerWidth - closeBtnWidth;
         this.segments = segments;
-        this.segmentWidth = (this.width / segments) - config.padding;
+        this.segmentWidth = (this.width / segments);
         
         this.progressSegments = [];
         this.createProgressBar(progress);
@@ -31,9 +31,10 @@ export default class ProgressBar extends Phaser.GameObjects.Container {
             const x = (i === 0) ? 0 : i * this.segmentWidth;
             // Place a graphics object at the x, y coordinates within the scene x, y coordinates set in the constructor
             const segment = this.scene.add.graphics({ x: x, y: 0 });
+            const segmentBackground = this.scene.add.graphics({ x: x, y: 0 });
 
-            const fillColor = (i <= progress) ? this.config.fillColor : this.config.backgroundColor;
-            segment.fillStyle(fillColor, 1);
+            segment.fillStyle(this.config.fillColor, 1);
+            segmentBackground.fillStyle(this.config.backgroundColor, 1);
 
             var rectRadius = 0; // no rounded corners
             // Apply rounded corners to first and last segments
@@ -53,8 +54,35 @@ export default class ProgressBar extends Phaser.GameObjects.Container {
                 }
             }
 
+            // determine the subprogress within each segment
+            // if the progress is more than the index range of the block then that segment can be fully filled
+            // otherwise if then we need to fill it based on the proportion of how many of the trials have been completed in that block
+
+            // examples, assume we are on trial 8
+            // trials 1-6 are completed in block 1 so we need to fill that segment with a full color
+            // trials 7-8 are complete so we fill that segment using the fill color
+            // trials 9-12 are incomplete so we fill that segment with a background color
+
+            const trialsPerBlock = this.config.trialsPerBlock;
+            const trialNumber = progress + 1.0; // Make the progress 1-indexed
+            let blockStart = (i * trialsPerBlock) + 1.0;
+            let blockEnd = (i + 1.0) * trialsPerBlock;
+
+            var blockProgress;
+            if (trialNumber < blockStart) {
+                blockProgress = 0.0; // Haven't reached the current block
+                segment.setAlpha(0);
+            } else if (trialNumber >= blockEnd) {
+                blockProgress = 1.0; // Completely fill the current block since its done
+            } else {
+                // need to standardize the trial number to be within a 1-blockLength range
+                let standardizedBlockStart = trialNumber % trialsPerBlock;
+                // if the standardizedBlockStart is 0 then we're at the end of this block so fill to 1.0. Otherwise fill based on proportion of trials completed in this block
+                blockProgress = standardizedBlockStart == 0 ? 1.0 :  standardizedBlockStart / trialsPerBlock;
+            }
+
             // Draw a rounded rectangle within the graphics x, y coordinates
-            segment.fillRoundedRect(
+            segmentBackground.fillRoundedRect(
                 0, // x: 0 as it's determined by the graphics object's x, y coordinates
                 0, // y: 0 as it's determined by the graphics object's x, y coordinates
                 this.segmentWidth - this.config.padding,
@@ -62,7 +90,22 @@ export default class ProgressBar extends Phaser.GameObjects.Container {
                 rectRadius
             );
 
+            // adjust the border radius of the segment for just the last section to have no border radius untill the last tick is filled
+            if (i == this.segments - 1 && blockProgress != 1.0) {
+                rectRadius = 0;
+            }
+
+            // draw in the filled section on top of the background
+            segment.fillRoundedRect(
+                0, // x: 0 as it's determined by the graphics object's x, y coordinates
+                0, // y: 0 as it's determined by the graphics object's x, y coordinates
+                (this.segmentWidth - this.config.padding) * blockProgress,
+                this.config.height,
+                rectRadius
+            );
+
             this.progressSegments.push(segment);
+            this.add(segmentBackground);
             this.add(segment);
         }
     }

--- a/public/src/elements/progressBar.js
+++ b/public/src/elements/progressBar.js
@@ -13,7 +13,7 @@ export default class ProgressBar extends Phaser.GameObjects.Container {
         };
         
         // Dynamically determine width based on screen width and close button
-        const closeBtnWidth = 55;
+        const closeBtnWidth = 65;
         this.width = window.innerWidth - closeBtnWidth;
         this.segments = segments;
         this.segmentWidth = (this.width / segments);

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -222,10 +222,11 @@ export default class MainTask extends Phaser.Scene {
         //////////////ADD PROGRESS BAR////////////////////
         const insetTop = EmbedContext.getInsetTop();
         // Create progress bar at the top of the screen with nBlocks segments
-        this.progressBar = new ProgressBar(this, 24, insetTop, nBlocks, blockNo, {
+        this.progressBar = new ProgressBar(this, 24, insetTop, nBlocks, trialNo, {
             height: 10,
             padding: 4,
-            cornerRadius: 5
+            cornerRadius: 5,
+            trialsPerBlock
         });
         // Make it stay fixed on screen (not affected by camera)
         this.progressBar.setScrollFactor(0);

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -157,7 +157,8 @@ export default class PracticeTask extends Phaser.Scene {
         this.progressBar = new ProgressBar(this, 24, insetTop, nPracTrials, pracTrial, {
             height: 10,
             padding: 4,
-            cornerRadius: 5
+            cornerRadius: 5,
+            trialsPerBlock: 1
         });
         // Make it stay fixed on screen (not affected by camera)
         this.progressBar.setScrollFactor(0);


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2613

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
The progress bar now shows subprogress within the block, this only changes the appearance for the main trial since the practice trial shows a full segment for each prac trial.

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run through the task the following should be observed:
- Practice task progress bar appears as it did before
- Main trials should show sub-progress as you progress through the blocks, the progression should be consistent throughout each block and the last block should not have a border radius until trial 24 when the bar is filled completely

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
<img width="447" alt="image" src="https://github.com/user-attachments/assets/f2416243-f93a-4c71-bdae-e1e6f42e4e7c" />
