### PR TITLE
Add the ability to resume an in-progress EEFRT task [CON-2615]

### DIFF
--- a/EEFRT Demo Android/app/build.gradle.kts
+++ b/EEFRT Demo Android/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.serialization)
 }
 
 android {
@@ -58,6 +59,8 @@ dependencies {
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
     implementation(libs.gson)
+    implementation(libs.krate)
+    implementation(libs.krate.kotlinx)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
@@ -42,7 +42,8 @@ class MainActivity : ComponentActivity() {
 
     private val eefrtScreenViewModel: EefrtScreenViewModel by lazy {
         EefrtScreenViewModel(
-            appDatabase
+            appDatabase,
+            this
         )
     }
 
@@ -64,6 +65,7 @@ fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
     NavHost(navController = navController, startDestination = NavigationScreens.HOME.route) {
         composable(NavigationScreens.HOME.route) {
             HomeScreen(
+                eefrtScreenViewModel = eefrtScreenViewModel,
                 onStartTaskPressed = {
                     navController.navigate(NavigationScreens.EFFRT.route)
                 },
@@ -123,6 +125,7 @@ fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
 
 @Composable
 fun HomeScreen(
+    eefrtScreenViewModel: EefrtScreenViewModel,
     onStartTaskPressed: () -> Unit,
     onViewEventLogsPressed: () -> Unit
 ) {
@@ -133,12 +136,18 @@ fun HomeScreen(
             modifier = Modifier.fillMaxSize()
         ) {
             AppButton(
-                name = "Begin EEFRT Task",
+                name = "Begin new EEFRT Task",
                 modifier = Modifier.padding(innerPadding),
                 onClick = onStartTaskPressed
             )
 
-            Spacer(modifier = Modifier.padding(vertical = 20.0.dp))
+            if (eefrtScreenViewModel.resumeTrialAvailable.value) {
+                AppButton(
+                    name = "Resume current EEFRT Task",
+                    modifier = Modifier.padding(innerPadding),
+                    onClick = onStartTaskPressed
+                )
+            }
 
             AppButton(
                 name = "View Event Logs",

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.Button
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import androidx.navigation.Navigator
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -67,6 +68,11 @@ fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
             HomeScreen(
                 eefrtScreenViewModel = eefrtScreenViewModel,
                 onStartTaskPressed = {
+                    eefrtScreenViewModel.setShouldUseCachedData(false)
+                    navController.navigate(NavigationScreens.EFFRT.route)
+                },
+                onResumeTaskPressed = {
+                    eefrtScreenViewModel.setShouldUseCachedData(true)
                     navController.navigate(NavigationScreens.EFFRT.route)
                 },
                 onViewEventLogsPressed = {
@@ -77,6 +83,7 @@ fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
 
         composable(NavigationScreens.EFFRT.route) {
             EefrtScreen(
+                useCachedData = eefrtScreenViewModel.getShouldUseCachedData(),
                 eefrtViewModel = eefrtScreenViewModel,
                 onBack = {
                     navController.popBackStack()
@@ -127,6 +134,7 @@ fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
 fun HomeScreen(
     eefrtScreenViewModel: EefrtScreenViewModel,
     onStartTaskPressed: () -> Unit,
+    onResumeTaskPressed: () -> Unit,
     onViewEventLogsPressed: () -> Unit
 ) {
     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
@@ -145,7 +153,7 @@ fun HomeScreen(
                 AppButton(
                     name = "Resume current EEFRT Task",
                     modifier = Modifier.padding(innerPadding),
-                    onClick = onStartTaskPressed
+                    onClick = onResumeTaskPressed
                 )
             }
 

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
@@ -1,0 +1,28 @@
+package ai.a2i2.conductor.effrtdemoandroid.persistence
+
+import android.content.Context
+import hu.autsoft.krate.SimpleKrate
+import hu.autsoft.krate.default.withDefault
+import hu.autsoft.krate.kotlinx.kotlinxPref
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GameCache(
+    val practiceComplete: Boolean,
+    val trialNumber: Int,
+    val maxPressCount: Int,
+    val coinRunningTotal: Int,
+    val trialResults: Map<String, Int>,
+    val randTrialsIdx: List<Int>
+)
+
+class GameStorage(context: Context) : SimpleKrate(context) {
+    private var cachedGameState: GameCache? by kotlinxPref<GameCache>("cachedGameState").withDefault(
+        null
+    )
+
+    fun getCurrentGameState(): GameCache? = cachedGameState
+    fun setCurrentGameState(newGameState: GameCache) {
+        cachedGameState = newGameState
+    }
+}

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
@@ -13,7 +13,7 @@ data class GameCache(
     val maxPressCount: Int,
     val coinRunningTotal: Int,
     val trialResults: Map<String, Int>,
-    val randTrialsIdx: List<Int>
+    val randTrialsIdx: List<Int>?
 )
 
 class GameStorage(context: Context) : SimpleKrate(context) {
@@ -22,7 +22,7 @@ class GameStorage(context: Context) : SimpleKrate(context) {
     )
 
     fun getCurrentGameState(): GameCache? = cachedGameState
-    fun setCurrentGameState(newGameState: GameCache) {
+    fun setCurrentGameState(newGameState: GameCache?) {
         cachedGameState = newGameState
     }
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -1,9 +1,12 @@
 package ai.a2i2.conductor.effrtdemoandroid.ui
 
+import ai.a2i2.conductor.effrtdemoandroid.persistence.GameCache
+import ai.a2i2.conductor.effrtdemoandroid.persistence.GameStorage
 import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtScreenViewModel
 import android.annotation.SuppressLint
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -21,6 +24,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
@@ -39,6 +43,7 @@ fun EefrtScreen(
 ) {
     val exitRequested = remember { mutableStateOf(false) }
     val webView = remember { mutableStateOf<WebView?>(null) }
+    val context = LocalContext.current
 
     val insets = WindowInsets.statusBars.asPaddingValues()
     val topPaddingDp = insets.calculateTopPadding().value.toInt()
@@ -83,7 +88,8 @@ fun EefrtScreen(
                                 message,
                                 onBack,
                                 exitRequested,
-                                eefrtViewModel
+                                eefrtViewModel,
+                                context
                             )
                         },
                         "AndroidBridge"
@@ -103,6 +109,7 @@ private fun handleMessage(
     onBack: () -> Unit,
     exitRequested: MutableState<Boolean>,
     eefrtViewModel: EefrtScreenViewModel,
+    context: Context
 ) {
     try {
         val obj = JSONObject(message)
@@ -135,6 +142,13 @@ private fun handleMessage(
                 val taskAttempt = gson.fromJson(body, TaskAttempt::class.java)
                 taskAttempt.createdAt = Date()
                 eefrtViewModel.saveActualTaskAttempt(taskAttempt)
+            }
+
+            "currentGameCache" -> {
+                val body = obj.getString("message")
+                val gson = Gson()
+                val gameCache = gson.fromJson(body, GameCache::class.java)
+                eefrtViewModel.setCurrentGameState(context, gameCache)
             }
 
             else -> Log.i(

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -31,6 +31,8 @@ import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import androidx.webkit.WebViewAssetLoader.DEFAULT_DOMAIN
 import androidx.webkit.WebViewClientCompat
 import com.google.gson.Gson
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.Date
@@ -38,6 +40,7 @@ import java.util.Date
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
 fun EefrtScreen(
+    useCachedData: Boolean = false,
     eefrtViewModel: EefrtScreenViewModel,
     onBack: () -> Unit,
 ) {
@@ -78,6 +81,19 @@ fun EefrtScreen(
                             // Attempt to resolve the url to an application resource or asset
                             return request?.let { req ->
                                 assetLoader.shouldInterceptRequest(req.url)
+                            }
+                        }
+
+                        override fun onPageFinished(view: WebView?, url: String?) {
+                            super.onPageFinished(view, url)
+
+                            // if we have a cached game state available, attempt to load it
+                            if (useCachedData) {
+                                GameStorage(context).getCurrentGameState()?.let {
+                                    val cacheJson = Json.encodeToString(it)
+                                    val jsString = "window.setupGameWithCache(${cacheJson});"
+                                    evaluateJavascript(jsString, null)
+                                }
                             }
                         }
                     }
@@ -149,6 +165,11 @@ private fun handleMessage(
                 val gson = Gson()
                 val gameCache = gson.fromJson(body, GameCache::class.java)
                 eefrtViewModel.setCurrentGameState(context, gameCache)
+            }
+
+            "gameComplete" -> {
+                eefrtViewModel.setCurrentGameState(context, null)
+                dismiss(onBack)
             }
 
             else -> Log.i(

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -20,6 +20,7 @@ class EefrtScreenViewModel(
 
     private val _practiceTrialData = mutableStateOf<List<PracticeTaskAttempt>>(emptyList())
     private val _actualTrialData = mutableStateOf<List<TaskAttempt>>(emptyList())
+    private val _shouldUseCachedData: MutableState<Boolean>
     val resumeTrialAvailable: MutableState<Boolean>
 
     init {
@@ -27,6 +28,7 @@ class EefrtScreenViewModel(
         val currentGameState = GameStorage(context).getCurrentGameState()
         resumeTrialAvailable =
             if (currentGameState == null) mutableStateOf(false) else mutableStateOf(true)
+        _shouldUseCachedData = mutableStateOf(resumeTrialAvailable.value)
     }
 
     private fun refreshData() {
@@ -81,8 +83,16 @@ class EefrtScreenViewModel(
         }
     }
 
-    fun setCurrentGameState(context: Context, newGameState: GameCache) {
+    fun setCurrentGameState(context: Context, newGameState: GameCache?) {
         GameStorage(context).setCurrentGameState(newGameState)
-        resumeTrialAvailable.value = true
+        resumeTrialAvailable.value = newGameState != null
+    }
+
+    fun getShouldUseCachedData(): Boolean {
+        return _shouldUseCachedData.value
+    }
+
+    fun setShouldUseCachedData(newValue: Boolean) {
+        _shouldUseCachedData.value = newValue
     }
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -1,8 +1,12 @@
 package ai.a2i2.conductor.effrtdemoandroid.ui.data
 
 import ai.a2i2.conductor.effrtdemoandroid.persistence.AppDatabase
+import ai.a2i2.conductor.effrtdemoandroid.persistence.GameCache
+import ai.a2i2.conductor.effrtdemoandroid.persistence.GameStorage
 import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
+import android.content.Context
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -10,17 +14,19 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 
 class EefrtScreenViewModel(
-    private val appDatabase: AppDatabase
+    private val appDatabase: AppDatabase,
+    context: Context
 ) : ViewModel() {
 
     private val _practiceTrialData = mutableStateOf<List<PracticeTaskAttempt>>(emptyList())
-    private val practiceTrialData: State<List<PracticeTaskAttempt>> = _practiceTrialData
-
     private val _actualTrialData = mutableStateOf<List<TaskAttempt>>(emptyList())
-    private val actualTrialData: State<List<TaskAttempt>> = _actualTrialData
+    val resumeTrialAvailable: MutableState<Boolean>
 
     init {
         refreshData()
+        val currentGameState = GameStorage(context).getCurrentGameState()
+        resumeTrialAvailable =
+            if (currentGameState == null) mutableStateOf(false) else mutableStateOf(true)
     }
 
     private fun refreshData() {
@@ -32,7 +38,7 @@ class EefrtScreenViewModel(
     }
 
     fun getPracticeTaskAttempts(): State<List<PracticeTaskAttempt>> {
-        return practiceTrialData
+        return _practiceTrialData
     }
 
     fun savePracticeTaskAttempt(practiceTaskAttempt: PracticeTaskAttempt) {
@@ -50,7 +56,7 @@ class EefrtScreenViewModel(
     }
 
     fun getActualTaskAttempts(): State<List<TaskAttempt>> {
-        return actualTrialData
+        return _actualTrialData
     }
 
     fun saveActualTaskAttempt(taskAttempt: TaskAttempt) {
@@ -73,5 +79,10 @@ class EefrtScreenViewModel(
             appDatabase.practiceTaskAttemptDao().deleteAllEvents()
             refreshData()
         }
+    }
+
+    fun setCurrentGameState(context: Context, newGameState: GameCache) {
+        GameStorage(context).setCurrentGameState(newGameState)
+        resumeTrialAvailable.value = true
     }
 }

--- a/EEFRT Demo Android/build.gradle.kts
+++ b/EEFRT Demo Android/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.serialization) apply false
 }

--- a/EEFRT Demo Android/gradle/libs.versions.toml
+++ b/EEFRT Demo Android/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ roomCommon = "2.6.1"
 roomKtx = "2.6.1"
 roomCompiler = "2.6.1"
 gson = "2.8.8"
+krate = "2.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -39,9 +40,12 @@ androidx-room-common = { group = "androidx.room", name = "room-common", version.
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "roomKtx" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "roomCompiler" }
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+krate = { group = "hu.autsoft", name = "krate", version.ref = "krate" }
+krate-kotlinx = { group = "hu.autsoft", name = "krate-kotlinx", version.ref = "krate" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }
+serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/EEFRT Demo iOS/EEFRT Demo.xcodeproj/project.pbxproj
+++ b/EEFRT Demo iOS/EEFRT Demo.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		8B0F92472DCC1F5A003EB354 /* SwiftyUserDefaults in Frameworks */ = {isa = PBXBuildFile; productRef = 8B0F92462DCC1F5A003EB354 /* SwiftyUserDefaults */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		8B34BEE72D78240000E73A72 /* EEFRT Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "EEFRT Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -26,6 +30,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8B0F92472DCC1F5A003EB354 /* SwiftyUserDefaults in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -68,6 +73,7 @@
 			);
 			name = "EEFRT Demo";
 			packageProductDependencies = (
+				8B0F92462DCC1F5A003EB354 /* SwiftyUserDefaults */,
 			);
 			productName = "EEFRT Demo";
 			productReference = 8B34BEE72D78240000E73A72 /* EEFRT Demo.app */;
@@ -97,6 +103,9 @@
 			);
 			mainGroup = 8B34BEDE2D78240000E73A72;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				8B0F92452DCC1F5A003EB354 /* XCRemoteSwiftPackageReference "SwiftyUserDefaults" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 8B34BEE82D78240000E73A72 /* Products */;
 			projectDirPath = "";
@@ -337,6 +346,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		8B0F92452DCC1F5A003EB354 /* XCRemoteSwiftPackageReference "SwiftyUserDefaults" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sunshinejr/SwiftyUserDefaults";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		8B0F92462DCC1F5A003EB354 /* SwiftyUserDefaults */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8B0F92452DCC1F5A003EB354 /* XCRemoteSwiftPackageReference "SwiftyUserDefaults" */;
+			productName = SwiftyUserDefaults;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 8B34BEDF2D78240000E73A72 /* Project object */;
 }

--- a/EEFRT Demo iOS/EEFRT Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EEFRT Demo iOS/EEFRT Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "771995780d580db7f57917fd8c1b8eea5cbe9f0ca5799ec81137121a06b2ef59",
+  "pins" : [
+    {
+      "identity" : "swiftyuserdefaults",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sunshinejr/SwiftyUserDefaults.git",
+      "state" : {
+        "revision" : "f66bcd04088582c8fbb5cb8554d577e303bae396",
+        "version" : "5.3.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
@@ -1,23 +1,37 @@
 import OSLog
 import SwiftData
 import SwiftUI
+import SwiftyUserDefaults
 
 struct ContentView: View {
+    @ObservedObject private var viewModel = ContentViewModel()
     @Environment(\.modelContext) private var modelContext
     @State private var shouldShowAlert = false
-    
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 20) {
                 NavigationLink(
                     destination: EEFRTView()
                         .ignoresSafeArea()
-                        .navigationBarBackButtonHidden()
-                    ,
+                        .navigationBarBackButtonHidden(),
+
                     label: {
-                        Text("Begin EEFRT Task")
+                        Text("Start new EEFRT Task")
                     }
                 )
+
+                if let cache = viewModel.gameCache {
+                    NavigationLink(
+                        destination: EEFRTView() // pass along config file
+                            .ignoresSafeArea()
+                            .navigationBarBackButtonHidden(),
+
+                        label: {
+                            Text("Resume current EEFRT Task")
+                        }
+                    )
+                }
 
                 NavigationLink(
                     destination:
@@ -49,25 +63,25 @@ struct ContentView: View {
             }
         }
     }
-    
+
     private func showAlert() {
         shouldShowAlert = true
     }
-    
+
     private func removeAllEventLogs() {
         let practiceEvents = try? modelContext.fetch(FetchDescriptor<PracticeTaskResult>())
         let actualEvents = try? modelContext.fetch(FetchDescriptor<TaskResult>())
-        
+
         guard let practiceEvents, let actualEvents else { return }
-        
+
         practiceEvents.forEach { practiceEvent in
             modelContext.delete(practiceEvent)
         }
-        
+
         actualEvents.forEach { trialData in
             modelContext.delete(trialData)
         }
-        
+
         do {
             try modelContext.save()
         } catch {

--- a/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
@@ -23,7 +23,7 @@ struct ContentView: View {
 
                 if let cache = viewModel.gameCache {
                     NavigationLink(
-                        destination: EEFRTView() // pass along config file
+                        destination: EEFRTView(gameCache: cache)
                             .ignoresSafeArea()
                             .navigationBarBackButtonHidden(),
 

--- a/EEFRT Demo iOS/EEFRT Demo/ContentViewModel.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/ContentViewModel.swift
@@ -1,0 +1,21 @@
+import OSLog
+import SwiftData
+import SwiftUI
+import SwiftyUserDefaults
+
+class ContentViewModel: ObservableObject {
+    @Published var gameCache: GameCache? = nil
+
+    private var defaultsObserver: DefaultsDisposable?
+
+    init() {
+        gameCache = Defaults.gameCache
+        defaultsObserver = Defaults.observe(\.gameCache, options: [.new]) { [weak self] newCache in
+            self?.gameCache = newCache.newValue?.map { $0 }
+        }
+    }
+
+    deinit {
+        defaultsObserver?.dispose()
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -14,8 +14,14 @@ struct EEFRTView: UIViewControllerRepresentable {
     @Environment(\.presentationMode) private var presentationMode
     @Environment(\.modelContext) private var context
 
+    private var gameCache: GameCache?
+
+    init(gameCache: GameCache? = nil) {
+        self.gameCache = gameCache
+    }
+
     func makeUIViewController(context: Context) -> EEFRTViewController {
-        let controller = EEFRTViewController()
+        let controller = EEFRTViewController(useCachedData: gameCache != nil)
         controller.delegate = context.coordinator
         return controller
     }
@@ -56,15 +62,17 @@ class EEFRTViewController: UIViewController {
     private static let practiceTrialResultMessageKey = "practiceTrialResult"
     private static let trialResultMessageKey = "trialResult"
     private static let currentGameCacheKey = "currentGameCache"
+    private static let gameCompleteKey = "gameComplete"
 
     weak var delegate: EEFRTViewControllerDelegate?
 
     private var webView: WKWebView!
+    private var useCachedData: Bool
 
     private let publicPath: String
     private let indexFileUrl: URL
 
-    init() {
+    init(useCachedData: Bool = false) {
         guard let publicPath = Bundle.main.path(forResource: "assets", ofType: nil) else {
             fatalError("Unable to locate 'assets' folder in main bundle")
         }
@@ -72,6 +80,7 @@ class EEFRTViewController: UIViewController {
             fatalError("Unable to locate 'assets/index.html' in main bundle")
         }
 
+        self.useCachedData = useCachedData
         self.publicPath = publicPath
         self.indexFileUrl = indexFileURL
         super.init(nibName: nil, bundle: nil)
@@ -114,8 +123,15 @@ class EEFRTViewController: UIViewController {
         config.userContentController.add(self, name: Self.practiceTrialResultMessageKey)
         config.userContentController.add(self, name: Self.trialResultMessageKey)
         config.userContentController.add(self, name: Self.currentGameCacheKey)
+        config.userContentController.add(self, name: Self.gameCompleteKey)
 
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
+
+        if useCachedData, let gameCache = try? Defaults.gameCache?.stringify() {
+            let gameCacheJsString = "window.setupGameWithCache(\(gameCache));"
+            let gameCacheUserScript = WKUserScript(source: gameCacheJsString, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+            config.userContentController.addUserScript(gameCacheUserScript)
+        }
 
         webView = WKWebView(frame: .zero, configuration: config)
         webView.scrollView.isScrollEnabled = false
@@ -181,6 +197,11 @@ extension EEFRTViewController: WKScriptMessageHandler {
             } catch {
                 os_log(.error, "Couldn't decode game cache from EEFRT task into a native object")
             }
+
+        case Self.gameCompleteKey:
+            // clear the cache as the user has finished the task
+            Defaults.gameCache = nil
+            delegate?.eefrtViewControllerDidRequestClose(self)
 
         default:
             os_log(.error, "Message type %s not implemented yet!", message.name)

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -1,5 +1,6 @@
 import os.log
 import SwiftUI
+import SwiftyUserDefaults
 import UIKit
 import WebKit
 
@@ -54,6 +55,7 @@ class EEFRTViewController: UIViewController {
     private static let closedMessageKey = "close"
     private static let practiceTrialResultMessageKey = "practiceTrialResult"
     private static let trialResultMessageKey = "trialResult"
+    private static let currentGameCacheKey = "currentGameCache"
 
     weak var delegate: EEFRTViewControllerDelegate?
 
@@ -92,8 +94,8 @@ class EEFRTViewController: UIViewController {
         let topInset: CGFloat = {
             guard
                 let windowScene = UIApplication.shared.connectedScenes
-                    .compactMap({ $0 as? UIWindowScene })
-                    .first(where: { $0.activationState == .foregroundActive }),
+                .compactMap({ $0 as? UIWindowScene })
+                .first(where: { $0.activationState == .foregroundActive }),
                 let window = windowScene.windows.first(where: { $0.isKeyWindow })
             else {
                 return 0.0
@@ -111,6 +113,7 @@ class EEFRTViewController: UIViewController {
         config.userContentController.add(self, name: Self.closedMessageKey)
         config.userContentController.add(self, name: Self.practiceTrialResultMessageKey)
         config.userContentController.add(self, name: Self.trialResultMessageKey)
+        config.userContentController.add(self, name: Self.currentGameCacheKey)
 
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
 
@@ -153,7 +156,7 @@ extension EEFRTViewController: WKScriptMessageHandler {
                 decodedPracticeTaskResult.createdAt = .now
                 delegate?.eefrtViewControllerDidSubmitPracticeResult(practiceResult: decodedPracticeTaskResult)
             } catch {
-                os_log(.error, "Couldn't decode response from EEFRT task into a native object")
+                os_log(.error, "Couldn't decode practice trial result from EEFRT task into a native object")
             }
 
         case Self.trialResultMessageKey:
@@ -164,13 +167,29 @@ extension EEFRTViewController: WKScriptMessageHandler {
                 decodedTaskResult.createdAt = .now
                 delegate?.eefrtViewControllerDidSubmitTaskResult(taskResult: decodedTaskResult)
             } catch {
-                os_log(.error, "Couldn't decode response from EEFRT task into a native object")
+                os_log(.error, "Couldn't decode main trial result from EEFRT task into a native object")
+            }
+
+        case Self.currentGameCacheKey:
+            guard let stringifiedData = (message.body as? String)?.data(using: .utf8) else { return }
+            do {
+                os_log(.debug, "%s", message.body as! String)
+                let decoder = JSONDecoder()
+                let decodedGameCacheString = try decoder.decode(String.self, from: stringifiedData)
+                let decodedGameCache = try decoder.decode(GameCache.self, from: Data(decodedGameCacheString.utf8))
+                Defaults.gameCache = decodedGameCache
+            } catch {
+                os_log(.error, "Couldn't decode game cache from EEFRT task into a native object")
             }
 
         default:
             os_log(.error, "Message type %s not implemented yet!", message.name)
         }
     }
+}
+
+extension DefaultsKeys {
+    var gameCache: DefaultsKey<GameCache?> { .init("gameCache", defaultValue: nil) }
 }
 
 private extension OSLog {

--- a/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
@@ -37,4 +37,13 @@ struct GameCache: Codable, DefaultsSerializable {
         case trialResults
         case randTrialsIdx
     }
+    
+    public func stringify() throws -> String {
+        let encoder = JSONEncoder()
+
+        let data = try encoder.encode(self)
+        let jsonString = String(decoding: data, as: UTF8.self)
+
+        return jsonString
+    }
 }

--- a/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftyUserDefaults
+
+struct GameCache: Codable, DefaultsSerializable {
+    var practiceComplete: Bool
+    var trialNumber: Int
+    var maxPressCount: Int
+    var coinRunningTotal: Int
+    var trialResults: [String: Int]
+    var randTrialsIdx: [Int]
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.practiceComplete = try container.decode(Bool.self, forKey: .practiceComplete)
+        self.trialNumber = try container.decode(Int.self, forKey: .trialNumber)
+        self.maxPressCount = try container.decode(Int.self, forKey: .maxPressCount)
+        self.coinRunningTotal = try container.decode(Int.self, forKey: .coinRunningTotal)
+        self.trialResults = try container.decode([String: Int].self, forKey: .trialResults)
+        self.randTrialsIdx = try container.decode([Int].self, forKey: .randTrialsIdx)
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(practiceComplete, forKey: .practiceComplete)
+        try container.encode(trialNumber, forKey: .trialNumber)
+        try container.encode(maxPressCount, forKey: .maxPressCount)
+        try container.encode(coinRunningTotal, forKey: .coinRunningTotal)
+        try container.encode(trialResults, forKey: .trialResults)
+        try container.encode(randTrialsIdx, forKey: .randTrialsIdx)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case practiceComplete
+        case trialNumber
+        case maxPressCount
+        case coinRunningTotal
+        case trialResults
+        case randTrialsIdx
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
@@ -7,7 +7,7 @@ struct GameCache: Codable, DefaultsSerializable {
     var maxPressCount: Int
     var coinRunningTotal: Int
     var trialResults: [String: Int]
-    var randTrialsIdx: [Int]
+    var randTrialsIdx: [Int]?
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -16,7 +16,7 @@ struct GameCache: Codable, DefaultsSerializable {
         self.maxPressCount = try container.decode(Int.self, forKey: .maxPressCount)
         self.coinRunningTotal = try container.decode(Int.self, forKey: .coinRunningTotal)
         self.trialResults = try container.decode([String: Int].self, forKey: .trialResults)
-        self.randTrialsIdx = try container.decode([Int].self, forKey: .randTrialsIdx)
+        self.randTrialsIdx = try container.decodeIfPresent([Int].self, forKey: .randTrialsIdx)
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -26,7 +26,7 @@ struct GameCache: Codable, DefaultsSerializable {
         try container.encode(maxPressCount, forKey: .maxPressCount)
         try container.encode(coinRunningTotal, forKey: .coinRunningTotal)
         try container.encode(trialResults, forKey: .trialResults)
-        try container.encode(randTrialsIdx, forKey: .randTrialsIdx)
+        try container.encodeIfPresent(randTrialsIdx, forKey: .randTrialsIdx)
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/public/index-debug.html
+++ b/public/index-debug.html
@@ -81,12 +81,12 @@
             import GameCache from './src/embedContext/GameCache.js'
             import { runTask } from "./src/task.js";
 
-            // Initiate the game, no longer need to rely info.js
-            runTask();
-
             window.setupGameWithCache = function(gameCache) {
                 GameCache.cache = gameCache;
             };
+
+            // Initiate the game, no longer need to rely info.js
+            runTask();
         </script>
 
         <script>

--- a/public/index-debug.html
+++ b/public/index-debug.html
@@ -78,14 +78,14 @@
 
         <!-- Main study components -->
         <script type="module">
-            import eventsCenter from './src/eventsCenter.js';
+            import GameCache from './src/embedContext/GameCache.js'
             import { runTask } from "./src/task.js";
 
-            // Initiate the game 
+            // Initiate the game, no longer need to rely info.js
             runTask();
 
-            window.breakOver = function() {
-                eventsCenter.emit('breakover');
+            window.setupGameWithCache = function(gameCache) {
+                GameCache.cache = gameCache;
             };
         </script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -49,14 +49,14 @@
 
         <!-- Main study components -->
         <script type="module">
-            import eventsCenter from './src/eventsCenter.js';
+            import GameCache from './src/embedContext/GameCache.js'
             import { runTask } from "./src/task.js";
 
             // Initiate the game, no longer need to rely info.js
             runTask();
 
-            window.breakOver = function() {
-                eventsCenter.emit('breakover');
+            window.setupGameWithCache = function(gameCache) {
+                GameCache.cache = gameCache;
             };
         </script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -52,12 +52,12 @@
             import GameCache from './src/embedContext/GameCache.js'
             import { runTask } from "./src/task.js";
 
-            // Initiate the game, no longer need to rely info.js
-            runTask();
-
             window.setupGameWithCache = function(gameCache) {
                 GameCache.cache = gameCache;
             };
+
+            // Initiate the game, no longer need to rely info.js
+            runTask();
         </script>
 
         <script nomodule>

--- a/public/src/embedContext/GameCache.js
+++ b/public/src/embedContext/GameCache.js
@@ -1,0 +1,14 @@
+export default class GameCache {
+    constructor(practiceComplete, trialNumber, maxPressCount, coinRunningTotal, trialResults, randTrialsIdx) {
+        this.practiceComplete = practiceComplete;
+        this.trialNumber = trialNumber;
+        this.maxPressCount = maxPressCount;
+        this.coinRunningTotal = coinRunningTotal;
+        this.trialResults = trialResults;
+        this.randTrialsIdx = randTrialsIdx;
+    }
+
+    stringify() {
+        return JSON.stringify(this);
+    }
+}

--- a/public/src/embedContext/GameCache.js
+++ b/public/src/embedContext/GameCache.js
@@ -1,4 +1,6 @@
 export default class GameCache {
+    static cache = null;
+
     constructor(practiceComplete, trialNumber, maxPressCount, coinRunningTotal, trialResults, randTrialsIdx) {
         this.practiceComplete = practiceComplete;
         this.trialNumber = trialNumber;

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -68,7 +68,7 @@ var practiceorReal = 1; // use the main task instruction panels
 var coinsWonThisTrial = 0;
 
 // pre-shuffle the trials here with nTrials specified in ./versionInfo.js
-var randTrialsIdx = shuffleTrials(nTrials, catchIdx, nCalibrates);
+var randTrialsIdx
 // check
 if (debug_mode) {
     console.log('random trial indices check: ' + randTrialsIdx)
@@ -172,6 +172,10 @@ export default class MainTask extends BaseScene {
         mapHeight = map.heightInPixels;
         mapWidth = map.widthInPixels;
 
+        // determine the maxPresscount and generate the randTrialsIdx if required
+        setUpMaxThreshold(this);
+        setUpRandTrialsIdx();
+
         // setup the game with the cached game state if present
         loadGameFromCache();
 
@@ -256,25 +260,6 @@ export default class MainTask extends BaseScene {
         //////////////////////////GET TRIAL INFO//////////////////////////////////  
         // load trial info (must be done within create())
         let trials = this.cache.json.get("trials"); // automates trials from version info 
-
-        // if a practice is run, take the minPressMax from the practice task
-        // otherwise assign maxPressCount as the fetched threshold max
-        if (runPractice == true && trialNo == 0) {
-            maxPressCount = this.registry.get('maxPressCount');
-            if (maxPressCount < minPressMax) {
-                // enforce minimum to guard against gaming from practice
-                maxPressCount = minPressMax;
-            }
-        }
-        else {
-            // add a catch if thresholdMax is undefined
-            if (typeof thresholdMax === "undefined") {
-                maxPressCount = thresholdAutoSet;
-
-            } else {
-                maxPressCount = thresholdMax; // fetch 
-            }
-        };
 
         // randomly select the order of trials for ema study:
         // save the random index:
@@ -615,8 +600,14 @@ var trialEnd = function () {
     trialEndTime = Math.round(this.time.now);
 
     // n.b. nCalibrates now set in versionInfo.js
-    // we only recalibrate if a practice was run first
-    if (trialNo < nCalibrates) {
+    // we completed the practice, but might be loading back from a cached run so we've already calibrated
+
+    var updatedNumCalibrates = nCalibrates;
+    if (GameCache.cache.practiceComplete == true && runPractice) {
+        updatedNumCalibrates = 0;
+    }
+
+    if (trialNo < updatedNumCalibrates) {
         // get variables to use 
         pressTimes = this.registry.get('pressTimes');
         pressCount = this.registry.get('pressCount');
@@ -786,8 +777,45 @@ var loadGameFromCache = function() {
     }
 
     // set up the game based on the previous state
-    trialNo = cache.trialNumber;
-    maxPressCount = cache.maxPressCount;
-    nCoins = cache.coinRunningTotal;
-    randTrialsIdx = cache.randTrialsIdx;
+    trialNo = cache.trialNumber ?? 0;
+    maxPressCount = cache.maxPressCount ?? thresholdAutoSet;
+    nCoins = cache.coinRunningTotal ?? 0;
+    randTrialsIdx = cache.randTrialsIdx ?? randTrialsIdx; // this was already set from the global scope so keep it if we dont have it in the cache
+}
+
+// sets up the max presses count depending on if the user did the practice or not
+var setUpMaxThreshold = function(context) {
+    // if a practice is run, take the minPressMax from the practice task
+    // otherwise assign maxPressCount as the fetched threshold max
+    if (runPractice == true && trialNo == 0) {
+        maxPressCount = context.registry.get('maxPressCount');
+        if (maxPressCount < minPressMax) {
+            // enforce minimum to guard against gaming from practice
+            maxPressCount = minPressMax;
+        }
+    }
+    else {
+        // add a catch if thresholdMax is undefined
+        if (typeof thresholdMax === "undefined") {
+            maxPressCount = thresholdAutoSet;
+
+        } else {
+            maxPressCount = thresholdMax; // fetch 
+        }
+    };
+}
+
+// checks the cache to see if we have a randTrialsIdx already to use, otherwise generates a new one and updates the cache with it
+var setUpRandTrialsIdx = function() {
+    randTrialsIdx = GameCache.cache?.randTrialsIdx ?? shuffleTrials(nTrials, catchIdx, nCalibrates);
+    if (GameCache.cache?.randTrialsIdx) {
+        // we have a cache available so use that value rather than generating a new randTrialsIdx
+        randTrialsIdx = GameCache.cache.randTrialsIdx
+    } else {
+        // no cache available, generate a new randTrialsIdx and update the cache with it
+        randTrialsIdx = shuffleTrials(nTrials, catchIdx, nCalibrates);
+        let cache = new GameCache(true, 0, maxPressCount, 0, {}, randTrialsIdx);
+        GameCache.cache = cache
+        EmbedContext.sendMessage('currentGameCache', JSON.stringify(cache));
+    }
 }

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -22,6 +22,7 @@ import {
 import Message from "../elements/message.js";
 import PowerPanel from "../elements/PowerPanel.js";
 import { POWER_UP_COMPLETE_KEY } from "../elements/PowerPanel.js";
+import GameCache from "../embedContext/GameCache.js";
 
 // initialize all the global vars (must be a better way of doing this...)
 var gameHeight; 
@@ -64,6 +65,7 @@ var trialEndTime;
 var maxPressCount;
 var thresholdMax;
 var practiceorReal = 1; // use the main task instruction panels 
+var coinsWonThisTrial = 0;
 
 // pre-shuffle the trials here with nTrials specified in ./versionInfo.js
 const randTrialsIdx = shuffleTrials(nTrials, catchIdx, nCalibrates);
@@ -669,6 +671,7 @@ var trialEnd = function () {
         trialSuccess = 0;
         pressStartTime = 0;
         pressEndTime = 0;
+        coinsWonThisTrial = 0;
     }
 
     // set data to be saved into registry
@@ -698,7 +701,16 @@ var trialEnd = function () {
     console.log(this.registry.get("trial" + trialNo));
     // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
     //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]
+    
+    // save the current coin choice to the registry
+    let coinChoices = this.registry.get("coinChoices") ?? {};
+    coinChoices['trial' + trialNo] = trialSuccess ? coinsWonThisTrial : 0;
+    this.registry.set("coinChoices", coinChoices);
+    let currentGameState = new GameCache(true, trialNo, maxPressCount, nCoins, coinChoices, randTrialsIdx);
 
+    // notify the native apps of what the current game state is so they can cache it
+    EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
+    
     // if end of task, display taskend screen 
     // if end of block, display end of block screen
     if ((trialNo + 1) % trialsPerBlock == 0 && trialNo != nTrials - 1) {
@@ -760,4 +772,5 @@ var onejump = function () {
 var collectCoins = function(player, coin, trial){
     coin.disableBody(true, true);   // individual coins from group become invisible upon overlap
     nCoins++;
+    coinsWonThisTrial++;
 };

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -68,7 +68,7 @@ var practiceorReal = 1; // use the main task instruction panels
 var coinsWonThisTrial = 0;
 
 // pre-shuffle the trials here with nTrials specified in ./versionInfo.js
-const randTrialsIdx = shuffleTrials(nTrials, catchIdx, nCalibrates);
+var randTrialsIdx = shuffleTrials(nTrials, catchIdx, nCalibrates);
 // check
 if (debug_mode) {
     console.log('random trial indices check: ' + randTrialsIdx)
@@ -171,6 +171,9 @@ export default class MainTask extends BaseScene {
         gameWidth = this.sys.game.config.width;
         mapHeight = map.heightInPixels;
         mapWidth = map.widthInPixels;
+
+        // setup the game with the cached game state if present
+        loadGameFromCache();
 
         // determine the background based on the current block (chapter)
         var bgStr = 'chapter-1-1';
@@ -702,13 +705,13 @@ var trialEnd = function () {
     // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
     //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]
     
-    // save the current coin choice to the registry
-    let coinChoices = this.registry.get("coinChoices") ?? {};
+    // save the current coin choice to the cache by adding on to the previous dictionary if present
+    let coinChoices = GameCache.cache?.trialResults ?? {};
     coinChoices['trial' + trialNo] = trialSuccess ? coinsWonThisTrial : 0;
-    this.registry.set("coinChoices", coinChoices);
-    let currentGameState = new GameCache(true, trialNo, maxPressCount, nCoins, coinChoices, randTrialsIdx);
 
     // notify the native apps of what the current game state is so they can cache it
+    let currentGameState = new GameCache(true, trialNo + 1, maxPressCount, nCoins, coinChoices, randTrialsIdx);
+    GameCache.cache = currentGameState;
     EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
     
     // if end of task, display taskend screen 
@@ -774,3 +777,17 @@ var collectCoins = function(player, coin, trial){
     nCoins++;
     coinsWonThisTrial++;
 };
+
+// function which restores the game state based on the given cache state
+var loadGameFromCache = function() {
+    const cache = GameCache.cache;
+    if (cache == null) {
+        return; // no cache to load from so just return
+    }
+
+    // set up the game based on the previous state
+    trialNo = cache.trialNumber;
+    maxPressCount = cache.maxPressCount;
+    nCoins = cache.coinRunningTotal;
+    randTrialsIdx = cache.randTrialsIdx;
+}

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -15,6 +15,7 @@ import eventsCenter from '../eventsCenter.js'
 import { effortTime, pracTrialEfforts, pracTrialRewards, timeout } from "../versionInfo.js";
 
 import Message from "../elements/message.js";
+import GameCache from "../embedContext/GameCache.js";
 
 // initialize some global vars
 var gameHeight;
@@ -68,6 +69,12 @@ export default class PracticeTask extends BaseScene {
     }
 
     preload() {
+        // skip the practice task if we've already completed it
+        if (GameCache.cache && GameCache.cache.practiceComplete) {
+            this.launchNextScene();
+            return;
+        }
+
         ////////////////////PRELOAD GAME ASSETS///////////////////////////////////
         // load tilemap and tileset created using Tiled (see below)
         this.load.tilemapTiledJSON('pmap', './src/assets/tilemaps/tilemap-main-grass.json');
@@ -113,6 +120,11 @@ export default class PracticeTask extends BaseScene {
     }
     
     create() {
+        // don't bother creating anything if we've already completed practice task, it will be skipped momentarily.
+        if (GameCache.cache && GameCache.cache.practiceComplete) {
+            return;
+        }
+
         ////////////////////////CREATE WORLD//////////////////////////////////////
         // game world created in Tiled (https://www.mapeditor.org/)
         // import practice world tilemap
@@ -244,6 +256,13 @@ export default class PracticeTask extends BaseScene {
     }
     
     update(time, delta) {
+        // backup check to skip the practice task already and it wasn't availiable to read during preload
+        if (GameCache.cache && GameCache.cache.practiceComplete) {
+            console.log("practice task passed");
+            this.launchNextScene();
+            return;
+        }
+
         ///////////SPRITES THAT REQUIRE TIME-STEP UPDATING FOR ANIMATION//////////
         // allow player to move
         this.player.update(); 

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -230,17 +230,17 @@ export default class PracticeTask extends BaseScene {
 
         // // 3. if desired, add listener functions to pause game when focus taken away
         // // from game browser tab/window [necessary for mobile devices]
-        window.addEventListener('blur', () => { 
-        console.log('pausing game content...');      // useful for debugging pause/resume
-            this.scene.pause();
-        }, false);
-        // // and resume when focus returns
-        window.addEventListener('focus', () => { 
-            setTimeout(() => {
-                console.log('resuming game content...');
-                this.scene.resume();
-            }, 250);
-        }, false);
+        // window.addEventListener('blur', () => { 
+        // console.log('pausing game content...');      // useful for debugging pause/resume
+        //     this.scene.pause();
+        // }, false);
+        // // // and resume when focus returns
+        // window.addEventListener('focus', () => { 
+        //     setTimeout(() => {
+        //         console.log('resuming game content...');
+        //         this.scene.resume();
+        //     }, 250);
+        // }, false);
     }
     
     update(time, delta) {

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -269,6 +269,11 @@ export default class PracticeTask extends BaseScene {
         
         ////////////MOVE ON TO NEXT SCENE WHEN ALL TRIALS HAVE RUN////////////////
         if (pracTrial == nPracTrials) {
+            // signal to the cache that the practice is complete
+            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null)
+            EmbedContext.sendMessage('currentGameCache', cache.stringify);
+
+            // progress to the next scene
             this.registry.set('maxPressCount', maxPressCount);
             this.launchNextScene();
         }

--- a/public/src/scenes/taskEndScene.js
+++ b/public/src/scenes/taskEndScene.js
@@ -102,7 +102,7 @@ export default class TaskEndScene extends Phaser.Scene {
         // end scene
         eventsCenter.once('page2complete', function () {
             if (runPractice == false) {
-                EmbedContext.sendMessage('close', {});
+                EmbedContext.sendMessage('gameComplete', {});
                 // for FU games without a practice, don't display prolific complete link
                 // BeApp.postMessage(JSON.stringify({
                 //     "type": "back",
@@ -120,7 +120,7 @@ export default class TaskEndScene extends Phaser.Scene {
                 // }))
             }
             else {
-                EmbedContext.sendMessage('close', {});
+                EmbedContext.sendMessage('gameComplete', {});
                 // for baseline games, display the complete link in postGame resources
                 // BeApp.postMessage(JSON.stringify({
                 //     "type": "back",


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2615

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- The game now tracks the progression state after each trial and bubble it up to the native apps
- The native apps respond to these events and save the `GameCache` in local shared preferences
- The native apps now contain a 'Continue current EEFRT task' button to resume from where they left off

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the following scenarios and it appeared to work fine:
- Normal playthrough of the task
- Resuming a task which has reached the main trials will not make you complete the practice again
- Resuming a task remembers the number of coins collected and at which trial (important for reward calculation)
- Resuming a task maintains the same randTrialsIdx order (you should see the same rewards/efforts before and after you pause the task)
- Playing through the practice and then exiting early on the first trial and then resuming the game works fine (ensuring any variables calculated during the trials were persisted and restored when we came back)
- Running the task with `runPractice = false` works as normal
- Completing the task will remove the resume button in the native apps

## Notes
While this PR technically will solve https://deakinuniversity.atlassian.net/browse/CON-2614, i'd like to keep them seperate as there will be other foldable phone specific optimisations which probably need to be implemented as well

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| iOS | Android |
| --- | --- |
| <img width="399" alt="image" src="https://github.com/user-attachments/assets/350a19c3-455b-44a8-9682-f7cbea1c0999" /> | <img width="404" alt="image" src="https://github.com/user-attachments/assets/dc5cb3a4-fb5b-49dd-ab4b-1831060af8b4" /> |

