### PR TITLE
Fix the BreakPanel spacing between items [CON-2622]

### DIFF
--- a/public/src/elements/BreakPanel.js
+++ b/public/src/elements/BreakPanel.js
@@ -5,9 +5,12 @@ const BREAK_TIME_MS = 120000; // 2 mins
 const BREAK_OVER_KEY = 'breakover';
 
 export default class BreakPanel {
-    constructor(scene, x, y, width, breakTimeMS = BREAK_TIME_MS) {
+    constructor(scene, x, breakTimeMS = BREAK_TIME_MS) {
         this.scene = scene;
         this.breakTimeMS = breakTimeMS;
+
+        let y = 0; // This coordinate will be calculated after the panel height is calculated
+        let width = window.innerWidth;
 
         // Register break over event listener
         eventsCenter.once(BREAK_OVER_KEY, () => {
@@ -32,7 +35,7 @@ export default class BreakPanel {
             y,
             width,
             height: 0,
-            space: { top: 30, bottom: 20, left: 25, right: 25, item: 20 }
+            space: { top: 30, bottom: 35, left: 25, right: 25, item: 20 }
         });
 
         // Header row: title + countdown
@@ -95,19 +98,16 @@ export default class BreakPanel {
                 this.continueButtonBg.setFillStyle(0xFFFFFF);
             });
 
-        const sizer = this.scene.rexUI.add.overlapSizer({
-            orientation: 'vertical',
-            space: { top: 0, bottom: 20, left: 0, right: 0 }
-        });
-
         // Assemble layout
         this.container.add(headerRow);
         this.container.add(this.breakText, { expand: true });
         this.container.add(this.continueButton, { expand: true });
-        this.container.add(sizer);
 
         this.container.layout();
         this.panelBg.height = this.container.height;
+        // Position at the bottom of the screen
+        this.container.y = window.innerHeight - this.panelBg.height / 2;
+        this.panelBg.y = window.innerHeight - this.panelBg.height / 2;
     }
 
     onContinuePressed() {

--- a/public/src/elements/BreakPanel.js
+++ b/public/src/elements/BreakPanel.js
@@ -5,7 +5,7 @@ const BREAK_TIME_MS = 120000; // 2 mins
 const BREAK_OVER_KEY = 'breakover';
 
 export default class BreakPanel {
-    constructor(scene, x, y, width, height, breakTimeMS = BREAK_TIME_MS) {
+    constructor(scene, x, y, width, breakTimeMS = BREAK_TIME_MS) {
         this.scene = scene;
         this.breakTimeMS = breakTimeMS;
 
@@ -23,7 +23,7 @@ export default class BreakPanel {
         // this.underlay.fillRect(scene.cameras.main.scrollX, 0, scene.cameras.main.width, scene.cameras.main.height);
 
         // Main panel background
-        this.panelBg = scene.rexUI.add.roundRectangle(x, y, width, height, { tl: 30, tr: 30, bl: 0, br: 0 }, 0xFFFFFF);
+        this.panelBg = scene.rexUI.add.roundRectangle(x, y, width, 0, { tl: 30, tr: 30, bl: 0, br: 0 }, 0xFFFFFF);
 
         // Outer vertical container
         this.container = scene.rexUI.add.sizer({
@@ -32,7 +32,7 @@ export default class BreakPanel {
             y,
             width,
             height: 0,
-            space: { top: 20, bottom: 20, left: 25, right: 25, item: 20 }
+            space: { top: 30, bottom: 20, left: 25, right: 25, item: 20 }
         });
 
         // Header row: title + countdown
@@ -95,12 +95,19 @@ export default class BreakPanel {
                 this.continueButtonBg.setFillStyle(0xFFFFFF);
             });
 
+        const sizer = this.scene.rexUI.add.overlapSizer({
+            orientation: 'vertical',
+            space: { top: 0, bottom: 20, left: 0, right: 0 }
+        });
+
         // Assemble layout
         this.container.add(headerRow);
         this.container.add(this.breakText, { expand: true });
         this.container.add(this.continueButton, { expand: true });
+        this.container.add(sizer);
 
         this.container.layout();
+        this.panelBg.height = this.container.height;
     }
 
     onContinuePressed() {

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -712,12 +712,9 @@ var trialEnd = function () {
         this.player.sprite.anims.play('wait', true);
         
         let camera = this.cameras.main;
-        let panelHeight = camera.height * 0.35;
         this.breakPanel = new BreakPanel(
             this,
-            camera.scrollX + camera.width / 2,
-            camera.height - panelHeight / 3,
-            camera.width,
+            camera.scrollX + camera.width / 2
         );
 
         this.tweens.add({        
@@ -739,7 +736,7 @@ var trialEnd = function () {
             // move to next trial
             this.scene.restart();    // [?wrap in delay function to ensure saving works]
         }, this);      
-    } 
+    }
     else {
         // iterate trial number
         trialNo++;     

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -716,9 +716,8 @@ var trialEnd = function () {
         this.breakPanel = new BreakPanel(
             this,
             camera.scrollX + camera.width / 2,
-            camera.height - panelHeight / 2,
+            camera.height - panelHeight / 3,
             camera.width,
-            panelHeight
         );
 
         this.tweens.add({        
@@ -731,7 +730,6 @@ var trialEnd = function () {
             yoyo: false
         });
 
-        // this.breakPanel = new BreakPanel(this, mapWidth-gameWidth/2, 600, nCoins);
         eventsCenter.once('breakover', function () {
             //  restart coin total from 0 after each block
             // nCoins=0; - keep coins to gamify


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2622

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
Updated the `BreakPanel` component so there is less excess spacing. It now longer must extend up 35% of the screen and takes up what it needs (which is usually less anyway)

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Set the `runPractice` flag to `false`
Ran the app on a variety of devices and check the break panel isn't broken

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
Devices from left to right:
Pixel 9 pro, Pixel 7, iPhone 16 Pro Max, iPhone SE 3rd gen, iPhone 16
<img width="1686" alt="image" src="https://github.com/user-attachments/assets/9af3b843-1c31-4d28-aa42-f65ab1d2051f" />
