### PR TITLE
Optimise the game a bit better for smaller devices [CON-2626]

### DIFF
--- a/public/src/elements/PowerPanel.js
+++ b/public/src/elements/PowerPanel.js
@@ -36,7 +36,7 @@ export default class PowerPanel {
             y,
             width,
             height,
-            space: { top: 20, bottom: 20, left: 25, right: 25, item: 20 }
+            space: { top: 20, bottom: 30, left: 25, right: 25, item: 20 }
         });
 
         const powerPanelState = Object.freeze({

--- a/public/src/elements/PowerPanel.js
+++ b/public/src/elements/PowerPanel.js
@@ -7,7 +7,7 @@ export const POWER_UP_COMPLETE_KEY = 'powerUpComplete';
 export const PRACTICE_POWER_UP_COMPLETE_KEY = 'practicePowerUpComplete';
 
 export default class PowerPanel {
-    constructor(scene, x, y, width, height, timeLimit, rewardCoins, power, trialEffort, isPractice = false) {
+    constructor(scene, x, timeLimit, rewardCoins, power, trialEffort, isPractice = false) {
         this.scene = scene;
         this.powerPercent = 0;
         this.powerText = (power * 100).toFixed();
@@ -19,6 +19,10 @@ export default class PowerPanel {
         this.pressCount = 0;
         this.pressTimes = [];
         this.timeLeft = timeLimit;
+
+        let y = 0; // This coordinate will be calculated after the panel height is calculated
+        let width = window.innerWidth;
+        let height = 0; // the height for the panel background will be calculated after the rest of the layout is done
 
         // Main panel background
         this.panelBg = scene.rexUI.add.roundRectangle(x, y, width, height, { tl: 30, tr: 30, bl: 0, br: 0 }, 0xFFFFFF)
@@ -209,6 +213,10 @@ export default class PowerPanel {
         this.container.add(this.powerButton, { expand: true });
 
         this.container.layout();
+
+        this.panelBg.height = this.container.height;
+        this.container.y = window.innerHeight - this.panelBg.height / 2;
+        this.panelBg.y = window.innerHeight - this.panelBg.height / 2;
 
         // Ran out of time to reach the trialEffort
         eventsCenter.once(POWER_UP_TIMEOUT_KEY, () => {

--- a/public/src/elements/RouteSelectorPanel.js
+++ b/public/src/elements/RouteSelectorPanel.js
@@ -5,7 +5,7 @@ import PowerMeterBar from './PowerMeterBar.js';
 const ROUTE_TIMEOUT_KEY = 'routeTimeout';
 
 export default class RouteSelectorPanel {
-    constructor(scene, x, y, width, height, route1Coins, route1Power, route2Coins, route2Power, onSelect, timeoutMillis = 10000) {
+    constructor(scene, x, route1Coins, route1Power, route2Coins, route2Power, onSelect, timeoutMillis = 10000) {
         this.scene = scene;
         this.route1Coins = route1Coins;
         this.route2Coins = route2Coins;
@@ -13,10 +13,12 @@ export default class RouteSelectorPanel {
         this.route2Power = (route2Power * 100).toFixed();
         this.onSelect = onSelect;
 
-        this.width = width;
+        this.width = window.innerWidth;
+        let y = 0; // This coordinate will be calculated after the panel height is calculated
+        let height = 0; // the height for the panel background will be calculated after the rest of the layout is done
 
         // background panel
-        this.panel = scene.rexUI.add.roundRectangle(x, y, width, height, 
+        this.panel = scene.rexUI.add.roundRectangle(x, y, this.width, height, 
             { // rounded corners top
                 tl: 30,
                 tr: 30,
@@ -32,7 +34,7 @@ export default class RouteSelectorPanel {
             orientation: 'vertical',
             x: x,
             y: y,
-            width: width,
+            width: this.width,
             height: height,
             // padding-space, and space between items
             space: { top: 20, bottom: 20, left: 20, right: 20, item: 20 }
@@ -71,6 +73,11 @@ export default class RouteSelectorPanel {
         this.container.add(optionsRow, { align: 'center' });
 
         this.container.layout();
+
+        // dynamically determine the panel height, y position and the container y position after the view layout has occured
+        this.panel.height = this.container.height;
+        this.container.y = window.innerHeight - this.panel.height / 2;
+        this.panel.y = window.innerHeight - this.panel.height / 2;
 
         if (timeoutMillis == null) {
             this.overlay = this.scene.add.graphics();

--- a/public/src/elements/RouteSelectorPanel.js
+++ b/public/src/elements/RouteSelectorPanel.js
@@ -37,7 +37,7 @@ export default class RouteSelectorPanel {
             width: this.width,
             height: height,
             // padding-space, and space between items
-            space: { top: 20, bottom: 20, left: 20, right: 20, item: 20 }
+            space: { top: 20, bottom: 30, left: 20, right: 20, item: 20 }
         });
 
         // Header: Title + Timer

--- a/public/src/elements/staticObjects.js
+++ b/public/src/elements/staticObjects.js
@@ -32,7 +32,7 @@ export default class StaticObjects {
      * Add a random object from our defined dictionary to the scene
      * @param {int} x coordinate for the object to be placed
      */
-    addRandomObject(x, ignoreTrees) {
+    addRandomObject(x, yOffset = 0, ignoreTrees) {
         if (ignoreTrees === undefined) {
             ignoreTrees = false;
         }
@@ -41,6 +41,6 @@ export default class StaticObjects {
         if (treeIndexes.includes(randomIndex) && ignoreTrees) return; // ignore trees if we need to, e.g. desert level
         let randomObj = staticObjects[randomIndex];
         if (randomObj.key === 'nothing') return; // sometimes we don't want to add an object
-        this.scene.obj.create(x, randomObj.y, randomObj.key).refreshBody();
+        this.scene.obj.create(x, randomObj.y + yOffset, randomObj.key).refreshBody();
     }
 };

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -411,7 +411,7 @@ var doChoice = function () {
     
     if (choice == 'route 1') {  // if participant chooses the high effort option
         // timer panel pops up  
-        this.powerPanel = new PowerPanel(this, centerX, this.cameras.main.height - 170, gameWidth, 340, effortTime, trialReward1, trialEffortPropMax1, trialEffort1);
+        this.powerPanel = new PowerPanel(this, centerX, effortTime, trialReward1, trialEffortPropMax1, trialEffort1);
         // and play player 'power-up' animation
         this.player.sprite.anims.play('powerup', true);
         // until time limit reached:
@@ -419,7 +419,7 @@ var doChoice = function () {
         }
     else if (choice == 'route 2') {  // if participant chooses the low effort option
         // timer panel pops up  
-        this.powerPanel = new PowerPanel(this, centerX, this.cameras.main.height - 170, gameWidth, 340, effortTime, trialReward2, trialEffortPropMax2, trialEffort2);
+        this.powerPanel = new PowerPanel(this, centerX, effortTime, trialReward2, trialEffortPropMax2, trialEffort2);
         // and play player 'power-up' animation
         this.player.sprite.anims.play('powerup', true);
         // until time limit reached:

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -378,8 +378,6 @@ var displayChoicePanel = function () {
     // display reward coins for each option
     this.coins1 = new Coins(this, midbridgeX-(trialReward1*30)/2, 235 + smallDeviceOffset, trialReward1); // coins in sky
     this.coins2 = new Coins(this, midbridgeX-(trialReward2*30)/2, 360 + smallDeviceOffset, trialReward2); // coins on bridge
-    // TODO: Fix how the coins are collected along the top row, 6 is fine for an iPhone SE but 7 will result in a missed coin. Bottom row is fine
-    // Consider keeping track of coins collected via trial information rather than actual coins collected in case game bugs out and coins are visually missed
 
     const camera = this.cameras.main;
     const centerX = camera.scrollX + camera.width / 2;
@@ -446,7 +444,8 @@ var effortOutcome = function() {
     if (choice == 'route 1' && pressCount >= trialEffort1) {
         trialSuccess = 1;
         // add overlap colliders so coins disappear when overlap with player body
-        this.physics.add.overlap(this.player.sprite, this.coins1.sprite, collectCoins, null, this); 
+        this.physics.add.overlap(this.player.sprite, this.coins1.sprite, collectCoins, null, this);
+
         // display success message for a couple of seconds,
         this.feedbackMessage = new Message(
             this,
@@ -700,6 +699,17 @@ var trialEnd = function () {
     // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
     //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]
     
+    // as a fallback for the case where the player misses the coins, we will add the coins regardless if the player touches them or not
+    if (trialSuccess && choice == 'route 1') {
+        coinsWonThisTrial = trialReward1;
+        nCoins += coinsWonThisTrial;
+    } else if (trialSuccess && choice == 'route 2') {
+        coinsWonThisTrial = trialReward2;
+        nCoins += coinsWonThisTrial;
+    } else {
+        coinsWonThisTrial = 0;
+    }
+
     // save the current coin choice to the cache by adding on to the previous dictionary if present
     let coinChoices = GameCache.cache?.trialResults ?? {};
     coinChoices['trial' + trialNo] = trialSuccess ? coinsWonThisTrial : 0;
@@ -752,7 +762,7 @@ var trialEnd = function () {
 //////////////////////MISC FUNCTIONS/////////////////////
 // function to get player up other side of bridge by performing single jump
 // used on reject and unsucessful accept trials
-var onejump = function () {
+var onejump = function() {
     this.bridgeEndPoint.destroy();
     let jumpHeight = -400;
     this.player.sprite.setVelocityY(jumpHeight);
@@ -762,10 +772,8 @@ var onejump = function () {
 
 // function to make coin sprites disappear upon contact with player
 // (so player appears to 'collect' them)
-var collectCoins = function(player, coin, trial){
+var collectCoins = function(player, coin, trial) {
     coin.disableBody(true, true);   // individual coins from group become invisible upon overlap
-    nCoins++;
-    coinsWonThisTrial++;
 };
 
 // function which restores the game state based on the given cache state

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -380,9 +380,6 @@ var displayChoicePanel = function () {
     const panel = new RouteSelectorPanel(
         this,
         centerX,
-        this.cameras.main.height - 170,
-        gameWidth,
-        340,
         trialReward1,
         trialEffortPropMax1,
         trialReward2,

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -195,7 +195,7 @@ export default class MainTask extends BaseScene {
             bgStr = `chapter-${blockNo+1}-${i}`;
         }
 
-        this.background = this.add.tileSprite(mapWidth/2, mapHeight/2.2, 1107, 970, bgStr);
+        this.background = this.add.tileSprite(mapWidth/2, mapHeight/2.2 + smallDeviceOffset, 1107, 970, bgStr);
 
         // import scene layers (using names set up in Tiled)
         platforms = map.createStaticLayer("platforms", tileset, 0, 0 + smallDeviceOffset);

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -66,6 +66,7 @@ var maxPressCount;
 var thresholdMax;
 var practiceorReal = 1; // use the main task instruction panels 
 var coinsWonThisTrial = 0;
+var smallDeviceOffset = 0;
 
 // pre-shuffle the trials here with nTrials specified in ./versionInfo.js
 var randTrialsIdx
@@ -168,6 +169,10 @@ export default class MainTask extends BaseScene {
         // setup the game with the cached game state if present
         loadGameFromCache();
 
+        if (window.innerHeight < 800) {
+            smallDeviceOffset = -175;
+        }
+
         // 3rd block is a "snow" level
         var mapKey = (blockNo == 2) ? 'snow-map' : 'grass-map';
         var map = this.make.tilemap({ key: mapKey });
@@ -193,8 +198,8 @@ export default class MainTask extends BaseScene {
         this.background = this.add.tileSprite(mapWidth/2, mapHeight/2.2, 1107, 970, bgStr);
 
         // import scene layers (using names set up in Tiled)
-        platforms = map.createStaticLayer("platforms", tileset, 0, 0);
-        bridge = map.createStaticLayer("bridge", tileset, 0, 0);
+        platforms = map.createStaticLayer("platforms", tileset, 0, 0 + smallDeviceOffset);
+        bridge = map.createStaticLayer("bridge", tileset, 0, 0 + smallDeviceOffset);
         
         // set up collision property for tiles that can be walked on (set in Tiled)
         platforms.setCollisionByProperty({ collide: true });
@@ -204,10 +209,10 @@ export default class MainTask extends BaseScene {
         let objManager = new StaticObjects(this);
         // determine decision x coordinate for left of bridge
         var x = Phaser.Math.RND.between(50, decisionPointX-60);
-        objManager.addRandomObject(x, blockNo === 1);
+        objManager.addRandomObject(x, smallDeviceOffset, blockNo === 1);
         // determine x coordinate for right of bridge
         x = Phaser.Math.RND.between(860, mapWidth-100);
-        objManager.addRandomObject(x, blockNo === 1);
+        objManager.addRandomObject(x, smallDeviceOffset, blockNo === 1);
 
         // set the boundaries of the world
         this.physics.world.bounds.width = mapWidth;
@@ -233,7 +238,7 @@ export default class MainTask extends BaseScene {
         });
 
         //////////////ADD PLAYER SPRITE////////////////////
-        this.player = new Player(this, 0, 350); // (this, spawnPoint.x, spawnPoint.y);
+        this.player = new Player(this, 0, 350 + smallDeviceOffset); // (this, spawnPoint.x, spawnPoint.y);
         this.physics.add.collider(this.player.sprite, platforms); 
         this.physics.add.collider(this.player.sprite, bridge);       // player walks on platforms and bridge
 
@@ -371,8 +376,10 @@ var displayChoicePanel = function () {
     this.decisionPoint.destroy();
     
     // display reward coins for each option
-    this.coins1 = new Coins(this, midbridgeX-(trialReward1*30)/2, 235, trialReward1); // coins in sky
-    this.coins2 = new Coins(this, midbridgeX-(trialReward2*30)/2, 360, trialReward2); // coins on bridge
+    this.coins1 = new Coins(this, midbridgeX-(trialReward1*30)/2, 235 + smallDeviceOffset, trialReward1); // coins in sky
+    this.coins2 = new Coins(this, midbridgeX-(trialReward2*30)/2, 360 + smallDeviceOffset, trialReward2); // coins on bridge
+    // TODO: Fix how the coins are collected along the top row, 6 is fine for an iPhone SE but 7 will result in a missed coin. Bottom row is fine
+    // Consider keeping track of coins collected via trial information rather than actual coins collected in case game bugs out and coins are visually missed
 
     const camera = this.cameras.main;
     const centerX = camera.scrollX + camera.width / 2;

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -59,6 +59,7 @@ const PRACTICE_TIMEOUT_KEY = 'practiceTimeout';
 const PRACTICE_CHOICE_KEY = 'practiceChoiceComplete';
 
 var routeSelectionTransitionTimer;
+var smallDeviceOffset = 0;
 
 // this function extends Phaser.Scene and includes the core logic for the game
 export default class PracticeTask extends BaseScene {
@@ -125,6 +126,11 @@ export default class PracticeTask extends BaseScene {
             return;
         }
 
+        // if we're on a smaller screen we want to shift most of the UI elements up so they are visible
+        if (window.innerHeight < 800) {
+            smallDeviceOffset = -175;
+        }
+
         ////////////////////////CREATE WORLD//////////////////////////////////////
         // game world created in Tiled (https://www.mapeditor.org/)
         // import practice world tilemap
@@ -140,8 +146,8 @@ export default class PracticeTask extends BaseScene {
         this.background = this.add.tileSprite(mapWidth/2, mapHeight/2.2, 1107, 970, "chapter-1-1");
 
         // import scene layers (using names set up in Tiled)
-        platforms = pmap.createStaticLayer("platforms", tileset, 0, 0);
-        bridge = pmap.createStaticLayer("bridge", tileset, 0, 0);
+        platforms = pmap.createStaticLayer("platforms", tileset, 0, smallDeviceOffset);
+        bridge = pmap.createStaticLayer("bridge", tileset, 0, smallDeviceOffset);
 
         // set up collision property for tiles that can be walked on (set in Tiled)
         platforms.setCollisionByProperty({ collide: true });
@@ -152,7 +158,7 @@ export default class PracticeTask extends BaseScene {
         for (var i = 0; i < 2; i++) {
             var x = 25;
             var y = 473;
-            this.plants.create(x, y, 'smallShrub').setScale(1.2).refreshBody();
+            this.plants.create(x, y + smallDeviceOffset, 'smallShrub').setScale(1.2).refreshBody();
         }
 
         // set the boundaries of the world
@@ -179,7 +185,7 @@ export default class PracticeTask extends BaseScene {
         });
 
         //////////////ADD PLAYER SPRITE////////////////////
-        this.player = new Player(this, 0, 300); // (this, spawnPoint.x, spawnPoint.y);
+        this.player = new Player(this, 0, 300 + smallDeviceOffset); // (this, spawnPoint.x, spawnPoint.y);
         this.physics.add.collider(this.player.sprite, platforms);    // player walks on platforms 
         this.physics.add.collider(this.player.sprite, bridge);       // player walks on platforms and bridge     
 
@@ -290,8 +296,8 @@ var displayInfoPanel = function () {
     
     // if the user is shown the route selection panel then we will want to show the coins
     if (pracTrial > 1) {
-        this.coins1 = new Coins(this, midbridgeX-(trialReward1*65)/2, 235, trialReward1); // coins in sky
-        this.coins2 = new Coins(this, midbridgeX-(trialReward2*155)/2, 360, trialReward2); // coins on bridge
+        this.coins1 = new Coins(this, midbridgeX-(trialReward1*65)/2, 235 + smallDeviceOffset, trialReward1); // coins in sky
+        this.coins2 = new Coins(this, midbridgeX-(trialReward2*155)/2, 360 + smallDeviceOffset, trialReward2); // coins on bridge
     }
 
     // each practice trial has a custom message displayed at the same time as the choice panel,
@@ -548,9 +554,10 @@ var effortOutcome = function() {
             // then player floats across 'high route' and collects coins
             this.time.addEvent({delay: pracFeedbackTime + 250, 
                 callback: function(){
+                    let playerSpeedAdjustment = window.innerHeight < 800 ? 4 : 3; // slow down the player a bit more on the smaller screens so they dont miss the coins
                     feedbackMessage?.destroy();
                     this.player.sprite.anims.play('float', true);    
-                    this.player.sprite.setVelocityX(playerVelocity/3);
+                    this.player.sprite.setVelocityX(playerVelocity/playerSpeedAdjustment);
                     this.time.addEvent({ delay: 120, 
                                         callback: function(){this.player.sprite.setVelocityY(-280);},
                                         callbackScope: this, 

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -143,7 +143,7 @@ export default class PracticeTask extends BaseScene {
         mapWidth = pmap.widthInPixels;
         mapHeight = pmap.heightInPixels;
 
-        this.background = this.add.tileSprite(mapWidth/2, mapHeight/2.2, 1107, 970, "chapter-1-1");
+        this.background = this.add.tileSprite(mapWidth/2, mapHeight/2.2 + smallDeviceOffset, 1107, 970, "chapter-1-1");
 
         // import scene layers (using names set up in Tiled)
         platforms = pmap.createStaticLayer("platforms", tileset, 0, smallDeviceOffset);

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -315,9 +315,6 @@ var displayInfoPanel = function () {
         this.instructionsPanel = new RouteSelectorPanel(
             this,
             centerX,
-            this.cameras.main.height - 170,
-            gameWidth,
-            340,
             trialReward1,
             trialEffortPropMax1,
             trialReward2,

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -438,7 +438,7 @@ var doChoice = function () {
     const centerX = camera.scrollX + camera.width / 2;
 
     // power panel pops up
-    this.powerPanel = new PowerPanel(this, centerX, this.cameras.main.height - 170, window.innerWidth, 340, effortTime, selectedReward, selectedEffortProp, selectedEffort, true);
+    this.powerPanel = new PowerPanel(this, centerX, effortTime, selectedReward, selectedEffortProp, selectedEffort, true);
     
     // we want to start the power up animation when the timer is actually counting down
     eventsCenter.once('powerStatePassed', startPowerUpAnimation, this);


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2626

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Updated the `PowerPanel` and the `RouteSelectorPanel` to now use the space it requires as well as a constant padding at the bottom
- Added a offset for smaller devices which pushes all the game objects up so the alien isn't being covered by the panels anymore
- Updated the way coins are collected so they are based off the trial reward rather than the coins the player makes actually makes contact with. This prevents users from getting less coins if the play the game on an unoptimised device where the player might make contact with all the coins despite reaching the power requirement

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on an iPhone SE and an 4 inch Android device:
1) Run the game from the start
2) Observe the positioning of the items on the smaller devices and how the dialogs dont cover the alien anymore
3) When you get to the 3rd practice trial, select the high effort option and complete it, you should be able to collect all the coins (notice the decreased player speed to make this occur)
4) On the 4th practice trial, select the low effort option and complete it, you should be able to collect the coins
5) Open up the web browser console so you can monitor the logs
6) Proceed to the main trials, Select the 1st option and then the 2nd option on the next trial and reach the power thresholds, ensure the visuals still are fine
7) Observe the logs as you complete the trials, confirm the coin count is still being updated correctly (unless youre using a very small device its unlikely you'll miss any coins along the top route)

Additionally:
Run the device on a normal sized device to ensure no regressions have occured (should be the same behaviour as the current master branch) 

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Power panel | route selector panel |
| --- | --- |
| <img width="1385" alt="image" src="https://github.com/user-attachments/assets/ef96e00a-eb54-4ba2-bace-6ebd3b99d1e7" /> | <img width="1375" alt="image" src="https://github.com/user-attachments/assets/1eefb03c-f409-48ab-b27e-8c363dd61bf2" /> |

