### PR TITLE
Update the readme with information on the trial result structure [CON-2628]

### DIFF
--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
@@ -20,7 +20,6 @@ data class PracticeTaskAttempt(
     @ColumnInfo(name = "press_count") val pressCount: Int,
     @ColumnInfo(name = "press_times") val pressTimes: List<Int>,
     @ColumnInfo(name = "trial_success") val trialSuccess: Int,
-    @ColumnInfo(name = "gems_running_total") val gemsRunningTotal: Int,
     @ColumnInfo(name = "max_press_count") val maxPressCount: Int,
 ) : EefrtTaskAttempt
 

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -168,7 +168,9 @@ extension EEFRTViewController: WKScriptMessageHandler {
             guard let stringifiedData = (message.body as? String)?.data(using: .utf8) else { return }
             do {
                 os_log(.debug, "%s", message.body as! String)
-                let decodedPracticeTaskResult = try JSONDecoder().decode(PracticeTaskResult.self, from: stringifiedData)
+                let decoder = JSONDecoder()
+                let decodedPracticeTaskResultString = try decoder.decode(String.self, from: stringifiedData)
+                let decodedPracticeTaskResult = try JSONDecoder().decode(PracticeTaskResult.self, from: Data(decodedPracticeTaskResultString.utf8))
                 decodedPracticeTaskResult.createdAt = .now
                 delegate?.eefrtViewControllerDidSubmitPracticeResult(practiceResult: decodedPracticeTaskResult)
             } catch {
@@ -179,7 +181,9 @@ extension EEFRTViewController: WKScriptMessageHandler {
             guard let stringifiedData = (message.body as? String)?.data(using: .utf8) else { return }
             do {
                 os_log(.debug, "%s", message.body as! String)
-                let decodedTaskResult = try JSONDecoder().decode(TaskResult.self, from: stringifiedData)
+                let decoder = JSONDecoder()
+                let decodedTaskResultString = try decoder.decode(String.self, from: stringifiedData)
+                let decodedTaskResult = try JSONDecoder().decode(TaskResult.self, from: Data(decodedTaskResultString.utf8))
                 decodedTaskResult.createdAt = .now
                 delegate?.eefrtViewControllerDidSubmitTaskResult(taskResult: decodedTaskResult)
             } catch {

--- a/EEFRT Demo iOS/EEFRT Demo/Models/PracticeTaskResult.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/PracticeTaskResult.swift
@@ -10,10 +10,9 @@ class PracticeTaskResult: Codable {
     var pressCount: Int
     var pressTimes: [Int]
     var trialSuccess: Int
-    var gemsRunningTotal: Int
     var maxPressCount: Int
 
-    init(pracTrialNo: Int, trialReward: Int, trialEffort: Int, pressCount: Int, pressTimes: [Int], trialSuccess: Int, gemsRunningTotal: Int, maxPressCount: Int) {
+    init(pracTrialNo: Int, trialReward: Int, trialEffort: Int, pressCount: Int, pressTimes: [Int], trialSuccess: Int, maxPressCount: Int) {
         self.createdAt = Date()
         self.pracTrialNo = pracTrialNo
         self.trialReward = trialReward
@@ -21,7 +20,6 @@ class PracticeTaskResult: Codable {
         self.pressCount = pressCount
         self.pressTimes = pressTimes
         self.trialSuccess = trialSuccess
-        self.gemsRunningTotal = gemsRunningTotal
         self.maxPressCount = maxPressCount
     }
 
@@ -34,10 +32,9 @@ class PracticeTaskResult: Codable {
         self.pressCount = try container.decode(Int.self, forKey: .pressCount)
         self.pressTimes = try container.decode([Int].self, forKey: .pressTimes)
         self.trialSuccess = try container.decode(Int.self, forKey: .trialSuccess)
-        self.gemsRunningTotal = try container.decode(Int.self, forKey: .gemsRunningTotal)
         self.maxPressCount = try container.decode(Int.self, forKey: .maxPressCount)
     }
-    
+
     func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(createdAt, forKey: .createdAt)
@@ -47,12 +44,10 @@ class PracticeTaskResult: Codable {
         try container.encode(pressCount, forKey: .pressCount)
         try container.encode(pressTimes, forKey: .pressTimes)
         try container.encode(trialSuccess, forKey: .trialSuccess)
-        try container.encode(gemsRunningTotal, forKey: .gemsRunningTotal)
         try container.encode(maxPressCount, forKey: .maxPressCount)
-
     }
 
     enum CodingKeys: String, CodingKey {
-        case createdAt, pracTrialNo, trialReward, trialEffort, pressCount, pressTimes, trialSuccess, gemsRunningTotal, maxPressCount
+        case createdAt, pracTrialNo, trialReward, trialEffort, pressCount, pressTimes, trialSuccess, maxPressCount
     }
 }

--- a/README.md
+++ b/README.md
@@ -58,3 +58,37 @@ npm run preview
 1. Original created by [Dr Agnes Norbury](https://www.agnesnorbury.com/); published in [Science Advances](https://www.science.org/doi/full/10.1126/sciadv.adk3222?af=R)
 
 2. The game world was compiled using [Tiled](https://www.mapeditor.org/) using art assets by [kenney](https://kenney.nl/). Based on the [phaser3](https://phaser.io/phaser3) and [rexUI plugins](https://rexrainbow.github.io/phaser3-rex-notes/docs/site/ui-overview/).
+
+## Response Data Structure
+Note: When 'Game Time' is mentioned it refers to the Clock used by the Phaser Game Engine which counts in milliseconds from the time the scene is originally created. The scene is restarted whenever a new trial occurs but will retain the same Clock for the scene and thus the the will continue to increment without resetting untill a new scene is raeached.
+
+### PracticeTaskAttempt
+`pracTrialNo`: Number - The current practice trial number. This value is 0-indexed.  
+`trialReward`: Number - The reward in coins for the current trial. For practice trials 1 & 2 (index 0 & 1) there is no visual reward but is automatically set to the higher effort threshold reward.  
+`trialEffort`: Int - The number of taps required to reach the effort threshold for the current practice trial.  
+`pressCount`: Int - The number of times the user pressed the power button during the power up animation.  
+`pressTimes`: Array[Number] - An array containing each time the power button was pressed curing the power up animation. Individual press counts are derived from the current Game Time at which the tap occured.  
+`trialSuccess`: Boolean - Whether or not the user reached the effort threshold current trial (0 or 1).  
+`maxPressCount`: Number - The maximum number of times the power button was pressed during the power up animation.  
+`createdAt`: Date - A timestamp measured in seconds since January 1, 1970 (UTC).  
+
+### TaskAttempt
+`trialNo`: Number - The trial number. This value is 0-indexed.  
+`trialStartTime`: Number - The current Game Time at which the current trial started.  
+`trialReward1`: Number - The reward in coins for the first choice for the current trial.  
+`trialEffort1`: Number - The number of taps required to reach the effort threshold for the first choice in the current trial.  
+`trialEffortPropMax1`: Float - A percentage value of the number of taps required to reach the effort threshold for the first choice in the current trial vs the `thresholdMax` determined from the calibration trials.  
+`trialReward2`: Number - The reward in coins for the second choice for the current trial.  
+`trialEffort2`: Number - The number of taps required to reach the effort threshold for the second choice in the current trial.  
+`trialEffortPropMax2`: Float - A percentage value of the number of taps required to reach the effort threshold for the second choice in the current trial vs the `thresholdMax` determined from the calibration trials.  
+`choice`: String - The user's choice of which reward they want ('route 1', 'route 2' or 'timeout').  
+`choiceRT`: Float - The time in milliseconds it took for the user to make their choice after being shown the RouteSelectorPanel.  
+`pressCount`: Number - The number of times the user pressed the power button during the power up animation.  
+`pressTimes`: Array[Number] - An array containing each time the power button was pressed curing the power up animation. Individual press counts are derived from the current Game Time at which the tap occured.  
+`trialSuccess`: Boolean - Whether or not the user reached the effort threshold current trial (0 or 1).  
+`coinsRunningTotal`: Float - The total number of coins the user has earned so far in the task across all completed trials.  
+`trialEndTime`: Number - The Game Time at which the current trial ended. the practice task ended.  
+`effortTimeLimit`: Number - The amount of time in milliseconds given to the user to reach the effort threshold for the current trial.  
+`recalibration`: Boolean - Whether or the `thresholdMax` was adjusted due to the user reaching a new maximum number of presses (0 or 1).  
+`thresholdMax`: Number - The maximum number of taps the user has achieved so far across all completed trials, include the calibration trials.  
+`createdAt`: Date - A timestamp measured in seconds since January 1, 1970 (UTC).  

--- a/public/src/embedContext/PracticeTaskAttempt.js
+++ b/public/src/embedContext/PracticeTaskAttempt.js
@@ -10,7 +10,6 @@ export default class PracticeTaskAttempt {
     }
 
     stringify() {
-        console.log(JSON.stringify(this));
         return JSON.stringify(this);
     }
 }

--- a/public/src/embedContext/PracticeTaskAttempt.js
+++ b/public/src/embedContext/PracticeTaskAttempt.js
@@ -1,0 +1,16 @@
+export default class PracticeTaskAttempt {
+    constructor(pracTrial, selectedReward, selectedEffort, pressCount, pressTimes, trialSuccess, maxPressCount) {
+        this.pracTrialNo = pracTrial
+        this.trialReward = selectedReward
+        this.trialEffort = selectedEffort
+        this.pressCount = pressCount
+        this.pressTimes = pressTimes
+        this.trialSuccess = trialSuccess
+        this.maxPressCount = maxPressCount
+    }
+
+    stringify() {
+        console.log(JSON.stringify(this));
+        return JSON.stringify(this);
+    }
+}

--- a/public/src/embedContext/TaskAttempt.js
+++ b/public/src/embedContext/TaskAttempt.js
@@ -1,0 +1,26 @@
+export default class TaskAttempt {
+    constructor(trialNo, trialStartTime, trialReward1, trialEffort1, trialEffortPropMax1, trialReward2, trialEffort2, trialEffortPropMax2, choice, choiceRT, pressCount, pressTimes, trialSuccess, coinsRunningTotal, trialEndTime, effortTimeLimit, recalibration, thresholdMax) {
+        this.trialNo = trialNo;
+        this.trialStartTime = trialStartTime;
+        this.trialReward1 = trialReward1;
+        this.trialEffort1 = trialEffort1;
+        this.trialEffortPropMax1 = trialEffortPropMax1;
+        this.trialReward2 = trialReward2;
+        this.trialEffort2 = trialEffort2;
+        this.trialEffortPropMax2 = trialEffortPropMax2;
+        this.choice = choice;
+        this.choiceRT = choiceRT;
+        this.pressCount = pressCount;
+        this.pressTimes = pressTimes;
+        this.trialSuccess = trialSuccess;
+        this.coinsRunningTotal = coinsRunningTotal;
+        this.trialEndTime = trialEndTime;
+        this.effortTimeLimit = effortTimeLimit;
+        this.recalibration = recalibration;
+        this.thresholdMax = thresholdMax;
+    }
+
+    stringify() {
+        return JSON.stringify(this);
+    }
+}

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -23,6 +23,7 @@ import Message from "../elements/message.js";
 import PowerPanel from "../elements/PowerPanel.js";
 import { POWER_UP_COMPLETE_KEY } from "../elements/PowerPanel.js";
 import GameCache from "../embedContext/GameCache.js";
+import TaskAttempt from "../embedContext/TaskAttempt.js";
 
 // initialize all the global vars (must be a better way of doing this...)
 var gameHeight; 
@@ -669,29 +670,32 @@ var trialEnd = function () {
     }
 
     // set data to be saved into registry
-    this.registry.set("trial" + trialNo, {
-                                    trialNo: trialNo,
-                                    trialStartTime: trialStartTime,
-                                    trialReward1: trialReward1,
-                                    trialEffort1: trialEffort1,
-                                    trialEffortPropMax1: trialEffortPropMax1,
-                                    trialReward2: trialReward2,
-                                    trialEffort2: trialEffort2,
-                                    trialEffortPropMax2: trialEffortPropMax2,
-                                    choice: choice,
-                                    choiceRT: choiceRT,
-                                    pressCount: pressCount,
-                                    pressTimes: pressTimes,
-                                    trialSuccess: trialSuccess,
-                                    coinsRunningTotal: nCoins,
-                                    trialEndTime: trialEndTime,
-                                    effortTimeLimit: effortTime,
-                                    recalibration: recalibration, // log of recalibration event
-                                    thresholdMax: thresholdMax !== undefined ? thresholdMax : maxPressCount // current max threshold or maxPressCount as autoset/practice
-                                     });
+    let taskAttempt = new TaskAttempt(
+        trialNo,
+        trialStartTime,
+        trialReward1,
+        trialEffort1,
+        trialEffortPropMax1,
+        trialReward2,
+        trialEffort2,
+        trialEffortPropMax2,
+        choice,
+        choiceRT,
+        pressCount,
+        pressTimes,
+        trialSuccess,
+        nCoins,
+        trialEndTime,
+        effortTime,
+        recalibration,
+        thresholdMax
+    );
+
+    // save the data in a registry for later retrieval
+    this.registry.set("trial" + trialNo, taskAttempt);
 
     // save data
-    EmbedContext.sendMessage("trialResult", this.registry.get("trial" + trialNo));
+    EmbedContext.sendMessage("trialResult", taskAttempt.stringify());
     console.log(this.registry.get("trial" + trialNo));
     // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
     //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -16,6 +16,7 @@ import { effortTime, pracTrialEfforts, pracTrialRewards, timeout } from "../vers
 
 import Message from "../elements/message.js";
 import GameCache from "../embedContext/GameCache.js";
+import PracticeTaskAttempt from "../embedContext/PracticeTaskAttempt.js";
 
 // initialize some global vars
 var gameHeight;
@@ -30,7 +31,6 @@ const endbridgeX = 765;        // where the player must jump up to cross bridge 
 const playerVelocity = 1000;   // baseline player velocity (rightward)
 // initialize practice task vars
 var pracTrial = 0;
-var nGems = 0;
 var nPracTrials = pracTrialRewards.length;
 var feedbackMessage;
 var pressCount;
@@ -637,18 +637,19 @@ var pracTrialEnd = function () {
        this.registry.set('maxPressCount', maxPressCount);
     }
     // set data to be saved into registry
-    this.registry.set("pracTrial"+pracTrial, {pracTrialNo: pracTrial, 
-                                              trialReward: selectedReward,
-                                              trialEffort: selectedReward,
-                                              pressCount: pressCount,
-                                              pressTimes: pressTimes,
-                                              trialSuccess: trialSuccess,
-                                              gemsRunningTotal: nGems,
-                                              maxPressCount: this.registry.get('maxPressCount')
-                                             });
+    let practiceTaskAttempt = new PracticeTaskAttempt(
+        pracTrial,
+        selectedReward, 
+        selectedEffort,
+        pressCount,
+        pressTimes,
+        trialSuccess,
+        this.registry.get('maxPressCount')
+    );
+    this.registry.set("pracTrial"+pracTrial, practiceTaskAttempt);
     // save data
     console.log(this.registry.get("pracTrial"+pracTrial));
-    EmbedContext.sendMessage("practiceTrialResult", this.registry.get("pracTrial"+pracTrial));
+    EmbedContext.sendMessage("practiceTrialResult", practiceTaskAttempt.stringify());
     // savePracTaskData(pracTrial, this.registry.get(`pracTrial${pracTrial}`));    // [for firebase]
     //saveTrialDataPav(this.registry.get(`pracTrial${pracTrial}`));             // [for Pavlovia deployment]
     
@@ -664,7 +665,6 @@ var pracTrialEnd = function () {
 // (so player appears to 'collect' them)
 var collectGems = function(player, gem) {
     gem.disableBody(true, true);      // individual gems from physics group become invisible upon overlap
-    nGems++; 
 };
 
 // function to get player up other side of bridge by performing single jump


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2628

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Created dedicated classes for the Practice and Main trial attempt results on the JS Side
- Removed the unused `gemsRunningTotal` field from the `PracticeTaskResult` since it isn't needed anymore
- Updated the `README` to include a breakdown of the Practice/Main trial result structures 

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested the app on both iOS and Android to make sure Practice and Main trial results are being saved. NOTE: You will need to delete and re-install the apps on both device as the database schemas have changed
- Look at the updated readme, any feedback on this would be greatly appreciated