### PR TITLE
Add in the 'Are you still there?' logic [CON-2361]

### DIFF
--- a/public/src/elements/BottomScreenPanel.js
+++ b/public/src/elements/BottomScreenPanel.js
@@ -1,29 +1,21 @@
 import CountdownPanel from "./CountdownPanel.js";
 import eventsCenter from "../eventsCenter.js";
 
-const BREAK_TIME_MS = 120000; // 2 mins
-const BREAK_OVER_KEY = 'breakover';
+export const TIMER_EXPIRED_KEY = 'bottomPanelTimerExpired';
 
-export default class BreakPanel {
-    constructor(scene, x, breakTimeMS = BREAK_TIME_MS) {
+export default class BottomScreenPanel {
+    constructor(scene, x, titleString, subtitleString, breakTimeMS, onContinuePressed = () => {}, onTimeout = () => {}) {
         this.scene = scene;
         this.breakTimeMS = breakTimeMS;
+        this.onTimeout = onTimeout;
 
         let y = 0; // This coordinate will be calculated after the panel height is calculated
         let width = window.innerWidth;
 
         // Register break over event listener
-        eventsCenter.once(BREAK_OVER_KEY, () => {
-            this.onTimeout();
+        eventsCenter.once(TIMER_EXPIRED_KEY, () => {
+            this.onTimerExpired();
         });
-
-        // FIXME: Grayed out underlay not extending all the way to the top of the screen
-        // - will require fixes to the layout on all devices in order to work properly
-        // Add grayed out underlay to the scene
-        // this.underlay = scene.add.graphics();
-        // this.underlay.fillStyle(0x000000, 1);
-        // this.underlay.setAlpha(0.25);
-        // this.underlay.fillRect(scene.cameras.main.scrollX, 0, scene.cameras.main.width, scene.cameras.main.height);
 
         // Main panel background
         this.panelBg = scene.rexUI.add.roundRectangle(x, y, width, 0, { tl: 30, tr: 30, bl: 0, br: 0 }, 0xFFFFFF);
@@ -41,23 +33,21 @@ export default class BreakPanel {
         // Header row: title + countdown
         const headerRow = scene.rexUI.add.sizer({ orientation: 'horizontal', space: { item: 40 } });
 
-        const titleText = scene.add.text(0, 0, 'Break time', {
+        const titleText = scene.add.text(0, 0, titleString, {
             fontSize: '20px',
             fontStyle: 'bold',
             fontFamily: 'DMSans',
             color: '#000000'
         });
 
-        this.countdownPanel = new CountdownPanel(this.scene, 0, 0, this.breakTimeMS, BREAK_OVER_KEY);
+        this.countdownPanel = new CountdownPanel(this.scene, 0, 0, this.breakTimeMS, TIMER_EXPIRED_KEY);
         headerRow.add(titleText, { expand: true });
         headerRow.add(this.countdownPanel.container);
 
         const textPadding = 20;
         const maxWidth = scene.cameras.main.width - (textPadding * 2);
 
-        let breakTextContent = "You\'re doing an amazing job!\nTake a short break if you need one. The task will automatically continue after 2 minutes."
-
-        this.breakText = scene.add.text(scene.cameras.main.scrollX, 0, breakTextContent, {
+        this.breakText = scene.add.text(scene.cameras.main.scrollX, 0, subtitleString, {
             fontSize: '14px',
             fontFamily: 'DMSans',
             color: '#000000',
@@ -92,7 +82,7 @@ export default class BreakPanel {
             })
             .on('pointerup', () => {
                 this.continueButtonBg.setFillStyle(0xFFFFFF);
-                this.onContinuePressed()
+                onContinuePressed()
             })
             .on('pointerout', () => {
                 this.continueButtonBg.setFillStyle(0xFFFFFF);
@@ -110,12 +100,9 @@ export default class BreakPanel {
         this.panelBg.y = window.innerHeight - this.panelBg.height / 2;
     }
 
-    onContinuePressed() {
-        eventsCenter.emit(BREAK_OVER_KEY);
-    }
-
-    onTimeout() {
+    onTimerExpired() {
         this.destroy();
+        this.onTimeout();
     }
 
     destroy() {

--- a/public/src/elements/CountdownPanel.js
+++ b/public/src/elements/CountdownPanel.js
@@ -9,7 +9,7 @@ export default class CountdownPanel {
         this.timeoutKey = timeoutKey;
 
         // Background
-        this.panel = scene.rexUI.add.roundRectangle(27.5, 0, 100, 30, 6, 0xF2F4F7);
+        this.panel = scene.rexUI.add.roundRectangle(21, 0, 90, 30, 6, 0xF2F4F7);
         this.panel.setOrigin(0.5);
         
         // Create the main container for our countdown elements

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -4,7 +4,7 @@ import { BaseScene } from "./baseScene.js";
 // import js game element modules (sprites, ui, outcome animations, etc.)
 import Player from "../elements/player.js";
 import Coins from "../elements/coins.js";
-import BreakPanel from "../elements/BreakPanel.js";
+import BottomScreenPanel from "../elements/BottomScreenPanel.js";
 import StaticObjects from "../elements/staticObjects.js";
 import ProgressBar from "../elements/progressBar.js";
 import RouteSelectorPanel from "../elements/RouteSelectorPanel.js";
@@ -16,7 +16,7 @@ import { shuffleTrials } from "../utils.js";
 import {
     runPractice, effortTime, nBlocks, nCalibrates, debug_mode,
     trialsFile, nTrials, catchIdx, minPressMax, thresholdAutoSet,
-    timeout
+    timeout, maxMissedTrials, breakTime
 } from "../versionInfo.js";
 
 import Message from "../elements/message.js";
@@ -68,6 +68,8 @@ var thresholdMax;
 var practiceorReal = 1; // use the main task instruction panels 
 var coinsWonThisTrial = 0;
 var smallDeviceOffset = 0;
+var missedTrials = 0;
+var missedTrialDialogShown = false;
 
 // pre-shuffle the trials here with nTrials specified in ./versionInfo.js
 var randTrialsIdx
@@ -444,6 +446,8 @@ var effortOutcome = function() {
     // if ppt chooses high effort and clears trial effort threshold, fly across sky and collect coins!
     if (choice == 'route 1' && pressCount >= trialEffort1) {
         trialSuccess = 1;
+        missedTrials = 0;
+
         // add overlap colliders so coins disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.coins1.sprite, collectCoins, null, this);
 
@@ -483,6 +487,8 @@ var effortOutcome = function() {
     // if ppt chooses low effect and clears trial effort threshold, fly across mid-sky and collect coins!
     else if (choice == 'route 2' && pressCount >= trialEffort2)  {
         trialSuccess = 1;
+        missedTrials = 0;
+
         // add overlap colliders so coins disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.coins2.sprite, collectCoins, null, this, trialNo); 
 
@@ -521,6 +527,7 @@ var effortOutcome = function() {
     }
     else if (choice == 'timeout') {
         trialSuccess = 0;
+        missedTrials += 1;
 
         // display failure message for a couple of seconds
         this.feedbackMessage = new Message(
@@ -559,6 +566,8 @@ var effortOutcome = function() {
 
     } else {  // else if fail to reach trial effort threshold
         trialSuccess = 0;
+        missedTrials = 0;
+
         // display failure message for a couple of seconds
         this.feedbackMessage = new Message(
             this,
@@ -722,38 +731,74 @@ var trialEnd = function () {
     let currentGameState = new GameCache(true, trialNo + 1, maxPressCount, nCoins, coinChoices, randTrialsIdx);
     GameCache.cache = currentGameState;
     EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
+
+    let isLastTrial = trialNo == nTrials - 1;
+    let camera = this.cameras.main;
+
+    // if the user has been shown the 'Are you still there?' message and they trigger it again, kick them out of the task
+    if (missedTrials >= maxMissedTrials && !isLastTrial && missedTrialDialogShown) {
+        exitGame();
+    }
     
-    // if end of task, display taskend screen 
-    // if end of block, display end of block screen
-    if ((trialNo + 1) % trialsPerBlock == 0 && trialNo != nTrials - 1) {
+    // If the 3rd missed trial ends up on the same trial as the break then we want to show the 'Are you still there?' message. If they press continue they will continue to the next block
+    if (missedTrials >= maxMissedTrials && !isLastTrial) {
         this.player.sprite.setVelocityX(0);
         this.player.sprite.anims.play('wait', true);
-        
-        let camera = this.cameras.main;
-        this.breakPanel = new BreakPanel(
+
+        let missedTrialsDialogText = "Continue within the next 2 minutes to keep collecting coins.";
+        missedTrialDialogShown = true;
+        missedTrials = 0;
+
+        this.bottomScreenPanel = new BottomScreenPanel(
             this,
-            camera.scrollX + camera.width / 2
-        );
+            camera.scrollX + camera.width / 2,
+            "Are you still there?",
+            missedTrialsDialogText,
+            breakTime,
+            () => { continueGameAfterBreak(this); },
+            () => { exitGame(); }
+        )
 
         this.tweens.add({        
-            targets: this.breakPanel,
+            targets: this.bottomScreenPanel,
             scaleX: { start: 0, to: 1 },
             scaleY: { start: 0, to: 1 },
             ease: 'Linear',    
             duration: animationTime,
             repeat: 0,      
             yoyo: false
-        });
+        }); 
 
-        eventsCenter.once('breakover', function () {
-            //  restart coin total from 0 after each block
-            // nCoins=0; - keep coins to gamify
-            // iterate trial number
-            trialNo++;
-            blockNo++;
-            // move to next trial
-            this.scene.restart();    // [?wrap in delay function to ensure saving works]
-        }, this);      
+        return;
+    }
+
+    // if end of task, display taskend screen 
+    // if end of block, display end of block screen
+    if ((trialNo + 1) % trialsPerBlock == 0 && !isLastTrial) {
+        this.player.sprite.setVelocityX(0);
+        this.player.sprite.anims.play('wait', true);
+        
+        let breakTextContent = "You\'re doing an amazing job!\nTake a short break if you need one. The task will automatically continue after 2 minutes."
+
+        this.bottomScreenPanel = new BottomScreenPanel(
+            this,
+            camera.scrollX + camera.width / 2,
+            "Break time",
+            breakTextContent,
+            breakTime,
+            () => { continueGameAfterBreak(this); }, // continue the game regardless after the break is automatically or manually stopped
+            () => { continueGameAfterBreak(this); }
+        );
+
+        this.tweens.add({        
+            targets: this.bottomScreenPanel,
+            scaleX: { start: 0, to: 1 },
+            scaleY: { start: 0, to: 1 },
+            ease: 'Linear',    
+            duration: animationTime,
+            repeat: 0,      
+            yoyo: false
+        });    
     }
     else {
         // iterate trial number
@@ -830,4 +875,21 @@ var setUpRandTrialsIdx = function() {
         GameCache.cache = cache
         EmbedContext.sendMessage('currentGameCache', JSON.stringify(cache));
     }
+}
+
+var continueGameAfterBreak = function(context) {
+    // iterate trial number
+    trialNo++;
+
+    // increment the block if required
+    if (trialNo % trialsPerBlock == 0) {
+        blockNo++;
+    }
+
+    // move to next trial
+    context.scene.restart();
+}
+
+var exitGame = function() {
+    EmbedContext.sendMessage('close');
 }

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -16,7 +16,7 @@ import { shuffleTrials } from "../utils.js";
 import {
     runPractice, effortTime, nBlocks, nCalibrates, debug_mode,
     trialsFile, nTrials, catchIdx, minPressMax, thresholdAutoSet,
-    timeout, maxMissedTrials, breakTime
+    timeout, missedTrialLimit, missedTrialDialogLimit, breakTime
 } from "../versionInfo.js";
 
 import Message from "../elements/message.js";
@@ -68,8 +68,8 @@ var thresholdMax;
 var practiceorReal = 1; // use the main task instruction panels 
 var coinsWonThisTrial = 0;
 var smallDeviceOffset = 0;
-var missedTrials = 0;
-var missedTrialDialogShown = false;
+var consecutiveMissedTrials = 0;
+var missedTrialDialogsShown = 0;
 
 // pre-shuffle the trials here with nTrials specified in ./versionInfo.js
 var randTrialsIdx
@@ -446,7 +446,7 @@ var effortOutcome = function() {
     // if ppt chooses high effort and clears trial effort threshold, fly across sky and collect coins!
     if (choice == 'route 1' && pressCount >= trialEffort1) {
         trialSuccess = 1;
-        missedTrials = 0;
+        consecutiveMissedTrials = 0;
 
         // add overlap colliders so coins disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.coins1.sprite, collectCoins, null, this);
@@ -487,7 +487,7 @@ var effortOutcome = function() {
     // if ppt chooses low effect and clears trial effort threshold, fly across mid-sky and collect coins!
     else if (choice == 'route 2' && pressCount >= trialEffort2)  {
         trialSuccess = 1;
-        missedTrials = 0;
+        consecutiveMissedTrials = 0;
 
         // add overlap colliders so coins disappear when overlap with player body
         this.physics.add.overlap(this.player.sprite, this.coins2.sprite, collectCoins, null, this, trialNo); 
@@ -527,7 +527,7 @@ var effortOutcome = function() {
     }
     else if (choice == 'timeout') {
         trialSuccess = 0;
-        missedTrials += 1;
+        consecutiveMissedTrials += 1;
 
         // display failure message for a couple of seconds
         this.feedbackMessage = new Message(
@@ -566,7 +566,7 @@ var effortOutcome = function() {
 
     } else {  // else if fail to reach trial effort threshold
         trialSuccess = 0;
-        missedTrials = 0;
+        consecutiveMissedTrials = 0;
 
         // display failure message for a couple of seconds
         this.feedbackMessage = new Message(
@@ -733,21 +733,22 @@ var trialEnd = function () {
     EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
 
     let isLastTrial = trialNo == nTrials - 1;
+    let missedTrialDialogShownLimitReached = (missedTrialDialogsShown >= missedTrialDialogLimit) && missedTrialDialogLimit > 0; // ensure that a limit of 0 allows the dialog to be shown as many times as needed
     let camera = this.cameras.main;
 
     // if the user has been shown the 'Are you still there?' message and they trigger it again, kick them out of the task
-    if (missedTrials >= maxMissedTrials && !isLastTrial && missedTrialDialogShown) {
+    if (consecutiveMissedTrials >= missedTrialLimit && !isLastTrial && missedTrialDialogShownLimitReached) {
         exitGame();
     }
     
     // If the 3rd missed trial ends up on the same trial as the break then we want to show the 'Are you still there?' message. If they press continue they will continue to the next block
-    if (missedTrials >= maxMissedTrials && !isLastTrial) {
+    if (consecutiveMissedTrials >= missedTrialLimit && !isLastTrial) {
         this.player.sprite.setVelocityX(0);
         this.player.sprite.anims.play('wait', true);
 
         let missedTrialsDialogText = "Continue within the next 2 minutes to keep collecting coins.";
-        missedTrialDialogShown = true;
-        missedTrials = 0;
+        missedTrialDialogsShown += 1;
+        consecutiveMissedTrials = 0;
 
         this.bottomScreenPanel = new BottomScreenPanel(
             this,

--- a/public/src/versionInfo.js
+++ b/public/src/versionInfo.js
@@ -58,10 +58,13 @@ var maxBonus = (maxCoins * bonusRate) / 100;
 var nGames = 8; 
 var MaxTotalBonus = completionBonus100 + (nGames * maxBonus);
 var completionMin = 80;
+var maxMissedTrials = 3; // allows 3 missed trials before showing the 'Are you still there?' message
+var breakTime = 120000; // 2 mins
 
 export {
 	demo_mode, debug_mode, randomiseOrder, runPractice,
 	completionMin, completionBonus80, completionBonus100, taskName, version, gameType, approxTime, bonusRate, maxBonus,
 	trialsFile, questionsFile, nTrials, catchIdx, maxCoins, thresholdAutoSet,
-	effortTime, timeout, gemHeights, pracTrialRewards, pracTrialEfforts, pracTrialEffortProp, minPressMax, nCalibrates, nBlocks, complete_link, buttonText, powerupDelay
+	effortTime, timeout, gemHeights, pracTrialRewards, pracTrialEfforts, pracTrialEffortProp, minPressMax, nCalibrates,
+	nBlocks, complete_link, buttonText, powerupDelay, maxMissedTrials, breakTime
 };

--- a/public/src/versionInfo.js
+++ b/public/src/versionInfo.js
@@ -58,7 +58,8 @@ var maxBonus = (maxCoins * bonusRate) / 100;
 var nGames = 8; 
 var MaxTotalBonus = completionBonus100 + (nGames * maxBonus);
 var completionMin = 80;
-var maxMissedTrials = 3; // allows 3 missed trials before showing the 'Are you still there?' message
+var missedTrialLimit = 3; // allows 3 missed trials before showing the 'Are you still there?' message
+var missedTrialDialogLimit = 1; // maximum number of times to show the 'Are you still there?' message before exiting the task automatically
 var breakTime = 120000; // 2 mins
 
 export {
@@ -66,5 +67,5 @@ export {
 	completionMin, completionBonus80, completionBonus100, taskName, version, gameType, approxTime, bonusRate, maxBonus,
 	trialsFile, questionsFile, nTrials, catchIdx, maxCoins, thresholdAutoSet,
 	effortTime, timeout, gemHeights, pracTrialRewards, pracTrialEfforts, pracTrialEffortProp, minPressMax, nCalibrates,
-	nBlocks, complete_link, buttonText, powerupDelay, maxMissedTrials, breakTime
+	nBlocks, complete_link, buttonText, powerupDelay, missedTrialLimit, missedTrialDialogLimit, breakTime
 };


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2631

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Refactored the `BreakPanel` into a more generic `BottomScreenPanel`
- Added the logic for the `Are you still there?` panel
- Made visual changes to the `CountdownPanel` so the circle and the text are more visually aligned with the background

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the task, when you reach the main trials, confirm the following cases work as expired (You'll also observe the CountdownPanel changes):
- Letting the break panel expire lets you continue to the next trial in the next block
- Pressing the continue button on the break panel lets you continue to the next trial in the next block
- Timing out for 3 trials and waiting out the 2 mins timer on the 'are you still there' dialog exits you from the task
- Timing out for 3 trials on 2 seperate occasions in the same play-through exits you from the task
- Timing out for 3 trials and pressing the continue button lets you continue from the next trial

## NOTES
- In the event both the break panel and the are you still there panel need to be shown at the same time, the are you still there panel takes precedence as discussed in yesterdays meeting

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Are you still there dialog  with updated countdown panel |
| --- |
| <img width="362" alt="image" src="https://github.com/user-attachments/assets/c54c7684-5860-44da-84f6-4e7db1c99d0b" /> |
