### PR TITLE
Add in the times up dialog [CON-2632]

### DIFF
--- a/public/src/elements/BottomScreenPanel.js
+++ b/public/src/elements/BottomScreenPanel.js
@@ -4,7 +4,7 @@ import eventsCenter from "../eventsCenter.js";
 export const TIMER_EXPIRED_KEY = 'bottomPanelTimerExpired';
 
 export default class BottomScreenPanel {
-    constructor(scene, x, titleString, subtitleString, breakTimeMS, onContinuePressed = () => {}, onTimeout = () => {}) {
+    constructor(scene, x, titleString, subtitleString, bottomButtonString, breakTimeMS, onContinuePressed = () => {}, onTimeout = () => {}) {
         this.scene = scene;
         this.breakTimeMS = breakTimeMS;
         this.onTimeout = onTimeout;
@@ -40,9 +40,13 @@ export default class BottomScreenPanel {
             color: '#000000'
         });
 
-        this.countdownPanel = new CountdownPanel(this.scene, 0, 0, this.breakTimeMS, TIMER_EXPIRED_KEY);
         headerRow.add(titleText, { expand: true });
-        headerRow.add(this.countdownPanel.container);
+
+        // add in the countdown panel if we've defined a timeout
+        if (breakTimeMS != null) {
+            this.countdownPanel = new CountdownPanel(this.scene, 0, 0, this.breakTimeMS, TIMER_EXPIRED_KEY);
+            headerRow.add(this.countdownPanel.container);
+        }
 
         const textPadding = 20;
         const maxWidth = scene.cameras.main.width - (textPadding * 2);
@@ -61,7 +65,7 @@ export default class BottomScreenPanel {
 
         this.continueButtonBg = scene.rexUI.add.roundRectangle(0, 0, 50, 0, 30, 0xFFFFFF);
         this.continueButtonBg.setStrokeStyle(2, 0xD64204);
-        this.continueButtonText = scene.add.text(0, 0, "CONTINUE", {
+        this.continueButtonText = scene.add.text(0, 0, bottomButtonString, {
             fontSize: '14px',
             fontFamily: 'DMSans',
             fontStyle: 'bold',

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -16,7 +16,7 @@ import { shuffleTrials } from "../utils.js";
 import {
     runPractice, effortTime, nBlocks, nCalibrates, debug_mode,
     trialsFile, nTrials, catchIdx, minPressMax, thresholdAutoSet,
-    timeout, missedTrialLimit, missedTrialDialogLimit, breakTime
+    timeout, missedTrialLimit, missedTrialDialogLimit, breakTime, taskRewardsPayoutThreshold
 } from "../versionInfo.js";
 
 import Message from "../elements/message.js";
@@ -732,74 +732,23 @@ var trialEnd = function () {
     GameCache.cache = currentGameState;
     EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
 
+    // if the user has been shown the 'Are you still there?' message and they trigger it again, kick them out of the task
     let isLastTrial = trialNo == nTrials - 1;
     let missedTrialDialogShownLimitReached = (missedTrialDialogsShown >= missedTrialDialogLimit) && missedTrialDialogLimit > 0; // ensure that a limit of 0 allows the dialog to be shown as many times as needed
-    let camera = this.cameras.main;
-
-    // if the user has been shown the 'Are you still there?' message and they trigger it again, kick them out of the task
     if (consecutiveMissedTrials >= missedTrialLimit && !isLastTrial && missedTrialDialogShownLimitReached) {
-        exitGame();
+        stopPlayer(this);
+        showTimeUpDialog(this);
     }
-    
     // If the 3rd missed trial ends up on the same trial as the break then we want to show the 'Are you still there?' message. If they press continue they will continue to the next block
-    if (consecutiveMissedTrials >= missedTrialLimit && !isLastTrial) {
-        this.player.sprite.setVelocityX(0);
-        this.player.sprite.anims.play('wait', true);
-
-        let missedTrialsDialogText = "Continue within the next 2 minutes to keep collecting coins.";
-        missedTrialDialogsShown += 1;
-        consecutiveMissedTrials = 0;
-
-        this.bottomScreenPanel = new BottomScreenPanel(
-            this,
-            camera.scrollX + camera.width / 2,
-            "Are you still there?",
-            missedTrialsDialogText,
-            breakTime,
-            () => { continueGameAfterBreak(this); },
-            () => { exitGame(); }
-        )
-
-        this.tweens.add({        
-            targets: this.bottomScreenPanel,
-            scaleX: { start: 0, to: 1 },
-            scaleY: { start: 0, to: 1 },
-            ease: 'Linear',    
-            duration: animationTime,
-            repeat: 0,      
-            yoyo: false
-        }); 
-
-        return;
+    else if (consecutiveMissedTrials >= missedTrialLimit && !isLastTrial) {
+        stopPlayer(this);
+        showMissedTrialDialog(this);
     }
-
     // if end of task, display taskend screen 
     // if end of block, display end of block screen
-    if ((trialNo + 1) % trialsPerBlock == 0 && !isLastTrial) {
-        this.player.sprite.setVelocityX(0);
-        this.player.sprite.anims.play('wait', true);
-        
-        let breakTextContent = "You\'re doing an amazing job!\nTake a short break if you need one. The task will automatically continue after 2 minutes."
-
-        this.bottomScreenPanel = new BottomScreenPanel(
-            this,
-            camera.scrollX + camera.width / 2,
-            "Break time",
-            breakTextContent,
-            breakTime,
-            () => { continueGameAfterBreak(this); }, // continue the game regardless after the break is automatically or manually stopped
-            () => { continueGameAfterBreak(this); }
-        );
-
-        this.tweens.add({        
-            targets: this.bottomScreenPanel,
-            scaleX: { start: 0, to: 1 },
-            scaleY: { start: 0, to: 1 },
-            ease: 'Linear',    
-            duration: animationTime,
-            repeat: 0,      
-            yoyo: false
-        });    
+    else if ((trialNo + 1) % trialsPerBlock == 0 && !isLastTrial) {
+        stopPlayer(this);
+        showBreakDialog(this);
     }
     else {
         // iterate trial number
@@ -893,4 +842,82 @@ var continueGameAfterBreak = function(context) {
 
 var exitGame = function() {
     EmbedContext.sendMessage('close');
+}
+
+var stopPlayer = function(context) {
+    context.player.sprite.setVelocityX(0);
+    context.player.sprite.anims.play('wait', true);
+}
+
+var showMissedTrialDialog = function(context) {
+    let missedTrialsDialogText = "Continue within the next 2 minutes to keep collecting coins.";
+    missedTrialDialogsShown += 1;
+    consecutiveMissedTrials = 0;
+
+    showBottomScreenPanel(
+        context,
+        "Are you still there?",
+        missedTrialsDialogText,
+        "CONTINUE",
+        breakTime,
+        () => { continueGameAfterBreak(context); },
+        () => { showTimeUpDialog(context); }
+    );
+}
+
+var showTimeUpDialog = function(context) {
+    var timeoutMessage;
+    if (trialNo + 1 >= nTrials * taskRewardsPayoutThreshold) {
+        timeoutMessage = "Unfortunately you've run out of time to continue the this task, but you'll still recieve a bonus payout.";
+    } else {
+        timeoutMessage = "Unfortunately you've run out of time to continue the this task. Try again to recieve a bonus payment.";
+    }
+
+    showBottomScreenPanel(
+        context,
+        "Times up!",
+        timeoutMessage,
+        "EXIT",
+        null,
+        () => { exitGame(); },
+        () => { exitGame(); }
+    );
+}
+
+var showBreakDialog = function(context) {
+    let breakTextContent = "You\'re doing an amazing job!\nTake a short break if you need one. The task will automatically continue after 2 minutes.";
+    showBottomScreenPanel(
+        context,
+        "Break time",
+        breakTextContent,
+        "CONTINUE",
+        breakTime,
+        () => { continueGameAfterBreak(context); }, // continue the game regardless after the break is automatically or manually stopped
+        () => { continueGameAfterBreak(context); }
+    );
+}
+
+var showBottomScreenPanel = function(context, titleText, subtitleText, bottomButtonText, countdownTimerMS, onContinuePressed, onTimeout) {
+    let camera = context.cameras.main;
+
+    context.bottomScreenPanel = new BottomScreenPanel(
+        context,
+        camera.scrollX + camera.width / 2,
+        titleText,
+        subtitleText,
+        bottomButtonText,
+        countdownTimerMS,
+        onContinuePressed,
+        onTimeout
+    );
+
+    context.tweens.add({        
+        targets: context.bottomScreenPanel,
+        scaleX: { start: 0, to: 1 },
+        scaleY: { start: 0, to: 1 },
+        ease: 'Linear',    
+        duration: animationTime,
+        repeat: 0,      
+        yoyo: false
+    });    
 }

--- a/public/src/versionInfo.js
+++ b/public/src/versionInfo.js
@@ -8,7 +8,7 @@ const randomiseOrder = true; // true: randomise the questions/game order upon ea
 const debug_mode = false; // turns on console logging 
 const demo_mode = true; // a demo game without study info
 // UPDATE runPRACTICE to false for FU games ///
-const runPractice = false; // run a practice i.e., a baseline version or without practice (FU)
+const runPractice = true; // run a practice i.e., a baseline version or without practice (FU)
 // trials:
 const trialsFile = "trials24.json" // name of the json file which includes trials
 const questionsFile = "questions.json" // json file storing the ema questions

--- a/public/src/versionInfo.js
+++ b/public/src/versionInfo.js
@@ -8,7 +8,7 @@ const randomiseOrder = true; // true: randomise the questions/game order upon ea
 const debug_mode = false; // turns on console logging 
 const demo_mode = true; // a demo game without study info
 // UPDATE runPRACTICE to false for FU games ///
-const runPractice = true; // run a practice i.e., a baseline version or without practice (FU)
+const runPractice = false; // run a practice i.e., a baseline version or without practice (FU)
 // trials:
 const trialsFile = "trials24.json" // name of the json file which includes trials
 const questionsFile = "questions.json" // json file storing the ema questions
@@ -61,11 +61,12 @@ var completionMin = 80;
 var missedTrialLimit = 3; // allows 3 missed trials before showing the 'Are you still there?' message
 var missedTrialDialogLimit = 1; // maximum number of times to show the 'Are you still there?' message before exiting the task automatically
 var breakTime = 120000; // 2 mins
+var taskRewardsPayoutThreshold = 0.8; // requires 80% of trials to be reached before offering monetary payout
 
 export {
 	demo_mode, debug_mode, randomiseOrder, runPractice,
 	completionMin, completionBonus80, completionBonus100, taskName, version, gameType, approxTime, bonusRate, maxBonus,
 	trialsFile, questionsFile, nTrials, catchIdx, maxCoins, thresholdAutoSet,
 	effortTime, timeout, gemHeights, pracTrialRewards, pracTrialEfforts, pracTrialEffortProp, minPressMax, nCalibrates,
-	nBlocks, complete_link, buttonText, powerupDelay, missedTrialLimit, missedTrialDialogLimit, breakTime
+	nBlocks, complete_link, buttonText, powerupDelay, missedTrialLimit, missedTrialDialogLimit, breakTime, taskRewardsPayoutThreshold
 };


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2632

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Added in the Times Up dialog
- Did some minor cleanup of the code to add the bottom screen dialog to the screen in the main task

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## Notes
Relies on https://github.com/a2i2/effort-expenditure-for-reward-task-mobile/pull/36

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1) Run the task, and reach the main trials
2) When you reach the main trials, time out 3 times in a row and get the <80% message
3) Dismiss the message 
4) Progress through the trials until you reach the 4th block
5) Time out again 3 times in a row and you will get the >80% message
---
1) Run another task, and reach the main trials
2) Time out 3 times in a row, then let the 'are you still there?' message to time out
3) Time out message is then shown.

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Less than 80% completion | Greater than 80% completion |
| --- | --- |
| <img width="364" alt="image" src="https://github.com/user-attachments/assets/d72df5a8-e374-4913-a580-288d18c88bde" /> | <img width="369" alt="image" src="https://github.com/user-attachments/assets/56082532-05b6-40f6-8717-d0ec6afba92e" /> |

