### PR TITLE
Add in the confirm exit dialog [CON-2633]

### DIFF
--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/MainActivity.kt
@@ -1,6 +1,7 @@
 package ai.a2i2.conductor.effrtdemoandroid
 
 import ai.a2i2.conductor.effrtdemoandroid.persistence.DatabaseProvider
+import ai.a2i2.conductor.effrtdemoandroid.persistence.GameCache
 import ai.a2i2.conductor.effrtdemoandroid.ui.EefrtScreen
 import ai.a2i2.conductor.effrtdemoandroid.ui.EventLogsView
 import ai.a2i2.conductor.effrtdemoandroid.ui.EefrtTrialDetailView
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.Button
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.Navigator
 import androidx.navigation.compose.NavHost
@@ -62,6 +64,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
     val navController = rememberNavController()
+    val context = LocalContext.current
 
     NavHost(navController = navController, startDestination = NavigationScreens.HOME.route) {
         composable(NavigationScreens.HOME.route) {
@@ -70,6 +73,7 @@ fun NavigationController(eefrtScreenViewModel: EefrtScreenViewModel) {
                 onStartTaskPressed = {
                     eefrtScreenViewModel.setShouldUseCachedData(false)
                     navController.navigate(NavigationScreens.EFFRT.route)
+                    eefrtScreenViewModel.setCurrentGameState(context, null) // we are starting a new eefrt task, remove any existing cached data
                 },
                 onResumeTaskPressed = {
                     eefrtScreenViewModel.setShouldUseCachedData(true)

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -121,7 +121,7 @@ fun EefrtScreen(
         )
 
         if (eefrtViewModel.showExitDialog.value) {
-            val message = if (eefrtViewModel.rewardThresholdReached)
+            val message = if (eefrtViewModel.rewardThresholdReached(context))
                 "You'll still receive a bonus but won't be able to return to the task and add to your bonus payment."
             else
                 "You have not completed enough rounds to earn the bonus payment and will lose your progress."
@@ -169,7 +169,14 @@ private fun handleMessage(
                     return
                 }
 
-                // if the close message doesn't contain the optional rewardThreshold flag then we just close the task
+                /*
+                    The exit behaviour is slightly different depending on if we've reached the main trials or not:
+                    If we've reached the main trials, show the exit dialog with the appropriate message based on their completion
+                    If they are still in the practice trials, just exit the task
+
+                    Messages from this key might contain an optional Boolean value which determines if the user reached the main trials or not
+                 */
+
                 if (obj.isNull("message")) {
                     Log.i(
                         TAG,
@@ -180,10 +187,10 @@ private fun handleMessage(
                     return
                 }
 
-                // if the close message contains an additional optional boolean flag we use that to
-                // determine if the 80% reward threshold is reached to show a dismiss dialog
-                val rewardThresholdReached = obj.getBoolean("message")
-                showDialogMessage(eefrtViewModel, rewardThresholdReached)
+                val mainTrialsReached = obj.getBoolean("message")
+                if (mainTrialsReached) {
+                    showDialogMessage(eefrtViewModel)
+                }
             }
 
             "practiceTrialResult" -> {
@@ -228,10 +235,6 @@ private fun dismiss(onBack: () -> Unit) {
     Handler(Looper.getMainLooper()).post { onBack() }
 }
 
-private fun showDialogMessage(
-    eefrtViewModel: EefrtScreenViewModel,
-    didReachRewardThreshold: Boolean
-) {
-    eefrtViewModel.rewardThresholdReached = didReachRewardThreshold
+private fun showDialogMessage(eefrtViewModel: EefrtScreenViewModel) {
     eefrtViewModel.showExitDialog.value = true
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -6,6 +6,7 @@ import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtScreenViewModel
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
@@ -19,6 +20,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -115,6 +119,35 @@ fun EefrtScreen(
                 }
             }
         )
+
+        if (eefrtViewModel.showExitDialog.value) {
+            val message = if (eefrtViewModel.rewardThresholdReached)
+                "You'll still receive a bonus but won't be able to return to the task and add to your bonus payment."
+            else
+                "You have not completed enough rounds to earn the bonus payment and will lose your progress."
+
+            AlertDialog(
+                onDismissRequest = { eefrtViewModel.showExitDialog.value = false },
+                title = { Text("Quit task?") },
+                text = { Text(message) },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            eefrtViewModel.showExitDialog.value = false
+
+                            dismiss(onBack)
+                        }
+                    ) {
+                        Text("Yes, quit task")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { eefrtViewModel.showExitDialog.value = false }) {
+                        Text("Cancel")
+                    }
+                }
+            )
+        }
     }
 }
 
@@ -135,13 +168,22 @@ private fun handleMessage(
                     Log.w(TAG, "User already requested close")
                     return
                 }
-                exitRequested.value = true
 
-                Log.i(
-                    TAG,
-                    String.format("User has dismissed eefrt task")
-                )
-                dismiss(onBack)
+                // if the close message doesn't contain the optional rewardThreshold flag then we just close the task
+                if (obj.isNull("message")) {
+                    Log.i(
+                        TAG,
+                        String.format("User has dismissed eefrt task")
+                    )
+                    exitRequested.value = true
+                    dismiss(onBack)
+                    return
+                }
+
+                // if the close message contains an additional optional boolean flag we use that to
+                // determine if the 80% reward threshold is reached to show a dismiss dialog
+                val rewardThresholdReached = obj.getBoolean("message")
+                showDialogMessage(eefrtViewModel, rewardThresholdReached)
             }
 
             "practiceTrialResult" -> {
@@ -184,4 +226,12 @@ private fun handleMessage(
 
 private fun dismiss(onBack: () -> Unit) {
     Handler(Looper.getMainLooper()).post { onBack() }
+}
+
+private fun showDialogMessage(
+    eefrtViewModel: EefrtScreenViewModel,
+    didReachRewardThreshold: Boolean
+) {
+    eefrtViewModel.rewardThresholdReached = didReachRewardThreshold
+    eefrtViewModel.showExitDialog.value = true
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -171,10 +171,11 @@ private fun handleMessage(
 
                 /*
                     The exit behaviour is slightly different depending on if we've reached the main trials or not:
-                    If we've reached the main trials, show the exit dialog with the appropriate message based on their completion
-                    If they are still in the practice trials, just exit the task
+                    If we've reached the main trials, show the exit dialog with the appropriate message based on their completion.
+                    If they are still in the practice trials, just exit the task.
+                    We also want to not show the exit dialog if they are shown the Times Up message.
 
-                    Messages from this key might contain an optional Boolean value which determines if the user reached the main trials or not
+                    Messages from this key will contain an Boolean value which determines if we show the exit dialog or not
                  */
 
                 if (obj.isNull("message")) {
@@ -187,9 +188,12 @@ private fun handleMessage(
                     return
                 }
 
-                val mainTrialsReached = obj.getBoolean("message")
-                if (mainTrialsReached) {
+                val shouldShowDialog = obj.getBoolean("message")
+                if (shouldShowDialog) {
                     showDialogMessage(eefrtViewModel)
+                } else {
+                    exitRequested.value = true
+                    dismiss(onBack)
                 }
             }
 

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -21,7 +21,10 @@ class EefrtScreenViewModel(
     private val _practiceTrialData = mutableStateOf<List<PracticeTaskAttempt>>(emptyList())
     private val _actualTrialData = mutableStateOf<List<TaskAttempt>>(emptyList())
     private val _shouldUseCachedData: MutableState<Boolean>
+
     val resumeTrialAvailable: MutableState<Boolean>
+    var showExitDialog: MutableState<Boolean> = mutableStateOf(false)
+    var rewardThresholdReached = false
 
     init {
         refreshData()

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -5,10 +5,12 @@ import ai.a2i2.conductor.effrtdemoandroid.persistence.GameCache
 import ai.a2i2.conductor.effrtdemoandroid.persistence.GameStorage
 import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
+import ai.a2i2.conductor.effrtdemoandroid.util.GameConfigUtils
 import android.content.Context
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
@@ -24,7 +26,6 @@ class EefrtScreenViewModel(
 
     val resumeTrialAvailable: MutableState<Boolean>
     var showExitDialog: MutableState<Boolean> = mutableStateOf(false)
-    var rewardThresholdReached = false
 
     init {
         refreshData()
@@ -97,5 +98,9 @@ class EefrtScreenViewModel(
 
     fun setShouldUseCachedData(newValue: Boolean) {
         _shouldUseCachedData.value = newValue
+    }
+
+    fun rewardThresholdReached(context: Context): Boolean {
+        return GameConfigUtils.rewardThresholdReached(context)
     }
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/util/GameConfigUtils.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/util/GameConfigUtils.kt
@@ -1,0 +1,17 @@
+package ai.a2i2.conductor.effrtdemoandroid.util
+
+import ai.a2i2.conductor.effrtdemoandroid.persistence.GameStorage
+import android.content.Context
+
+class GameConfigUtils {
+    companion object {
+        const val REWARD_PAYMENT_THRESHOLD = 0.8
+
+        fun rewardThresholdReached(context: Context): Boolean {
+            val trialNumber = GameStorage(context).getCurrentGameState()?.trialNumber?.plus(1) ?: 0
+            val nTrials = GameStorage(context).getCurrentGameState()?.randTrialsIdx?.size ?: 0
+            val minTrialsCompleted = (nTrials * REWARD_PAYMENT_THRESHOLD).toInt()
+            return trialNumber >= minTrialsCompleted
+        }
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -131,6 +131,10 @@ class EEFRTViewController: UIViewController {
             let gameCacheJsString = "window.setupGameWithCache(\(gameCache));"
             let gameCacheUserScript = WKUserScript(source: gameCacheJsString, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
             config.userContentController.addUserScript(gameCacheUserScript)
+        } else {
+            DispatchQueue.main.async {
+                Defaults.gameCache = nil
+            }
         }
 
         webView = WKWebView(frame: .zero, configuration: config)

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -154,6 +154,35 @@ class EEFRTViewController: UIViewController {
         super.viewWillAppear(animated)
         webView.loadFileURL(indexFileUrl, allowingReadAccessTo: URL(fileURLWithPath: publicPath))
     }
+
+    private func showDismissDialog(didReachRewardThreshold: Bool) {
+        let message = didReachRewardThreshold
+            ? "You'll still receive a bonus but won't be able to return to the task and add to your bonus payment."
+            : "You have not completed enough rounds to earn the bonus payment and will lose your progress."
+
+        let alert = UIAlertController(
+            title: "Quit task?",
+            message: message,
+            preferredStyle: .alert
+        )
+        alert.addAction(
+            UIAlertAction(
+                title: "Cancel",
+                style: .cancel
+            )
+        )
+        alert.addAction(
+            UIAlertAction(
+                title: "Yes, quit task",
+                style: .default
+            ) { [weak self] _ in
+                guard let self else { return }
+                delegate?.eefrtViewControllerDidRequestClose(self)
+            }
+        )
+
+        present(alert, animated: true)
+    }
 }
 
 extension EEFRTViewController: WKScriptMessageHandler {
@@ -162,7 +191,14 @@ extension EEFRTViewController: WKScriptMessageHandler {
 
         switch message.name {
         case Self.closedMessageKey:
-            delegate?.eefrtViewControllerDidRequestClose(self)
+            guard let didReachRewardThresholdFromJS = message.body as? String,
+                  let didReachRewardThreshold = Bool(didReachRewardThresholdFromJS) else {
+                // couldnt find a flag to signal that the user reached the reward threshold, just exit the task
+                delegate?.eefrtViewControllerDidRequestClose(self)
+                return
+            }
+
+            showDismissDialog(didReachRewardThreshold: didReachRewardThreshold)
 
         case Self.practiceTrialResultMessageKey:
             guard let stringifiedData = (message.body as? String)?.data(using: .utf8) else { return }

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -197,19 +197,22 @@ extension EEFRTViewController: WKScriptMessageHandler {
         case Self.closedMessageKey:
             /*
                 The exit behaviour is slightly different depending on if we've reached the main trials or not:
-                If we've reached the main trials, show the exit dialog with the appropriate message based on their completion
-                If they are still in the practice trials, just exit the task
+                If we've reached the main trials, show the exit dialog with the appropriate message based on their completion.
+                If they are still in the practice trials, just exit the task.
+                We also want to not show the exit dialog if they are shown the Times Up message.
 
-                Messages from this key will contain an optional Boolean value which determines if the user reached the main trials or not
+                Messages from this key will contain an Boolean value which determines if we show the exit dialog or not
              */
-            guard let reachedMainTrialsFromJs = message.body as? String,
-                  let reachedMainTrials = Bool(reachedMainTrialsFromJs) else {
+            guard let shouldShowExitDialogFromJs = message.body as? String,
+                  let shouldShowExitDialog = Bool(shouldShowExitDialogFromJs) else {
                 delegate?.eefrtViewControllerDidRequestClose(self)
                 return
             }
 
-            if reachedMainTrials {
+            if shouldShowExitDialog {
                 showDismissDialog()
+            } else {
+                delegate?.eefrtViewControllerDidRequestClose(self)
             }
 
         case Self.practiceTrialResultMessageKey:

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -159,8 +159,8 @@ class EEFRTViewController: UIViewController {
         webView.loadFileURL(indexFileUrl, allowingReadAccessTo: URL(fileURLWithPath: publicPath))
     }
 
-    private func showDismissDialog(didReachRewardThreshold: Bool) {
-        let message = didReachRewardThreshold
+    private func showDismissDialog() {
+        let message = GameConfigUtils.rewardThresholdReached()
             ? "You'll still receive a bonus but won't be able to return to the task and add to your bonus payment."
             : "You have not completed enough rounds to earn the bonus payment and will lose your progress."
 
@@ -195,14 +195,22 @@ extension EEFRTViewController: WKScriptMessageHandler {
 
         switch message.name {
         case Self.closedMessageKey:
-            guard let didReachRewardThresholdFromJS = message.body as? String,
-                  let didReachRewardThreshold = Bool(didReachRewardThresholdFromJS) else {
-                // couldnt find a flag to signal that the user reached the reward threshold, just exit the task
+            /*
+                The exit behaviour is slightly different depending on if we've reached the main trials or not:
+                If we've reached the main trials, show the exit dialog with the appropriate message based on their completion
+                If they are still in the practice trials, just exit the task
+
+                Messages from this key will contain an optional Boolean value which determines if the user reached the main trials or not
+             */
+            guard let reachedMainTrialsFromJs = message.body as? String,
+                  let reachedMainTrials = Bool(reachedMainTrialsFromJs) else {
                 delegate?.eefrtViewControllerDidRequestClose(self)
                 return
             }
 
-            showDismissDialog(didReachRewardThreshold: didReachRewardThreshold)
+            if reachedMainTrials {
+                showDismissDialog()
+            }
 
         case Self.practiceTrialResultMessageKey:
             guard let stringifiedData = (message.body as? String)?.data(using: .utf8) else { return }

--- a/EEFRT Demo iOS/EEFRT Demo/Utills/GameConfigUtils.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Utills/GameConfigUtils.swift
@@ -1,0 +1,14 @@
+import Foundation
+import SwiftyUserDefaults
+
+struct GameConfigUtils {
+    private static let rewardPaymentThreshold = 0.8
+
+    static func rewardThresholdReached() -> Bool {
+        guard let cache = Defaults.gameCache,
+              let nTrials = cache.randTrialsIdx?.count else { return false }
+
+        let nTrialsToReachThreshold = Int(Double(nTrials) * rewardPaymentThreshold)
+        return cache.trialNumber + 1 >= nTrialsToReachThreshold
+    }
+}

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -841,8 +841,7 @@ var continueGameAfterBreak = function(context) {
 }
 
 var exitGame = function() {
-    const rewardPaymentThresholdReached = trialNo + 1 >= nTrials * taskRewardsPayoutThreshold
-    EmbedContext.sendMessage('close', rewardPaymentThresholdReached);
+    EmbedContext.sendMessage('close', true);
 }
 
 var stopPlayer = function(context) {

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -237,7 +237,8 @@ export default class MainTask extends BaseScene {
         this.closeButton.setScrollFactor(0);
         this.closeButton.setInteractive();
         this.closeButton.on('pointerdown', () => {
-            exitGame();
+            let shouldShowExitDialog = true
+            exitGame(shouldShowExitDialog);
         });
 
         //////////////ADD PLAYER SPRITE////////////////////
@@ -840,8 +841,8 @@ var continueGameAfterBreak = function(context) {
     context.scene.restart();
 }
 
-var exitGame = function() {
-    EmbedContext.sendMessage('close', true);
+var exitGame = function(shouldShowExitDialog) {
+    EmbedContext.sendMessage('close', shouldShowExitDialog);
 }
 
 var stopPlayer = function(context) {
@@ -879,8 +880,8 @@ var showTimeUpDialog = function(context) {
         timeoutMessage,
         "EXIT",
         null,
-        () => { exitGame(); },
-        () => { exitGame(); }
+        () => { exitGame(false); }, // no need to show the exit dialog as we're already showing the time up dialog
+        () => { exitGame(false); } // no need to show the exit dialog as we're already showing the time up dialog
     );
 }
 

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -237,7 +237,7 @@ export default class MainTask extends BaseScene {
         this.closeButton.setScrollFactor(0);
         this.closeButton.setInteractive();
         this.closeButton.on('pointerdown', () => {
-            EmbedContext.sendMessage('close');
+            exitGame();
         });
 
         //////////////ADD PLAYER SPRITE////////////////////
@@ -841,7 +841,8 @@ var continueGameAfterBreak = function(context) {
 }
 
 var exitGame = function() {
-    EmbedContext.sendMessage('close');
+    const rewardPaymentThresholdReached = trialNo + 1 >= nTrials * taskRewardsPayoutThreshold
+    EmbedContext.sendMessage('close', rewardPaymentThresholdReached);
 }
 
 var stopPlayer = function(context) {

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -181,7 +181,8 @@ export default class PracticeTask extends BaseScene {
         this.closeButton.setScrollFactor(0);
         this.closeButton.setInteractive();
         this.closeButton.on('pointerdown', () => {
-            EmbedContext.sendMessage('close');
+            let shouldShowExitDialog = false
+            EmbedContext.sendMessage('close', shouldShowExitDialog);
         });
 
         //////////////ADD PLAYER SPRITE////////////////////

--- a/public/src/scenes/startTaskScene.js
+++ b/public/src/scenes/startTaskScene.js
@@ -36,7 +36,8 @@ export default class StartTaskScene extends BaseScene {
         this.closeButton.setScrollFactor(0);
         this.closeButton.setInteractive();
         this.closeButton.on('pointerup', () => {
-            EmbedContext.sendMessage('close');
+            let shouldShowExitDialog = false
+            EmbedContext.sendMessage('close', shouldShowExitDialog);
         });
 
         const container = this.rexUI.add.sizer({


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2633

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Added the close confirmation dialog for both native apps, slight refactor to how this is handled on both JS and native sides to allow us to determine if the 80% threshold is reached or not

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On both platforms:
1) Start the practice task, attempt to close the task. You will exit straight away
2) Complete the practice task and reach the main trials
3) Attempt to exit immediately, you'll get the exit confirmation dialog and the message will mention that you aren't eligible for the payout
4) Progress through the trials untill you are about halfway through the last block
5) Attempt to close again, you'll still get the dialog but the message will have changed, confirm it states you're eligible for the payout

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->

| android - reward reached | android - reward not reached | ios - reward reached | ios - reward not reached |
| --- | --- | --- | --- |
| <img width="366" alt="image" src="https://github.com/user-attachments/assets/5dc9b09e-4009-43af-b132-155692469953" /> | <img width="362" alt="image" src="https://github.com/user-attachments/assets/61c460e2-0b00-4f08-a2ae-cd0e6587a901" /> | <img width="362" alt="image" src="https://github.com/user-attachments/assets/47782c54-3e55-4b3e-9eb5-d88ac76454a2" /> | <img width="363" alt="image" src="https://github.com/user-attachments/assets/8bf4b324-95cc-4443-8cf8-39f9e2d140cd" /> |
