### PR TITLE
Ensure there is a max number of trials [CON-2644]

### DIFF
--- a/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
@@ -37,7 +37,7 @@ struct ContentView: View {
             }
             .padding()
             .navigationDestination(isPresented: $navigateToEEFRT) {
-                EEFRTView(gameCache: viewModel.gameCache!)
+                EEFRTView(gameCache: viewModel.gameCache)
                     .ignoresSafeArea()
                     .navigationBarBackButtonHidden()
             }

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -14,9 +14,9 @@ struct EEFRTView: UIViewControllerRepresentable {
     @Environment(\.presentationMode) private var presentationMode
     @Environment(\.modelContext) private var context
 
-    private var gameCache: GameCache
+    private var gameCache: GameCache?
 
-    init(gameCache: GameCache) {
+    init(gameCache: GameCache?) {
         self.gameCache = gameCache
     }
 
@@ -67,12 +67,12 @@ class EEFRTViewController: UIViewController {
     weak var delegate: EEFRTViewControllerDelegate?
 
     private var webView: WKWebView!
-    private var gameCache: GameCache
+    private var gameCache: GameCache?
 
     private let publicPath: String
     private let indexFileUrl: URL
 
-    init(gameCache: GameCache) {
+    init(gameCache: GameCache?) {
         guard let publicPath = Bundle.main.path(forResource: "assets", ofType: nil) else {
             fatalError("Unable to locate 'assets' folder in main bundle")
         }
@@ -127,7 +127,7 @@ class EEFRTViewController: UIViewController {
 
         config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
 
-        if let gameCache = try? gameCache.stringify() {
+        if let gameCache = try? gameCache?.stringify() {
             let gameCacheJsString = "window.setupGameWithCache(\(gameCache));"
             let gameCacheUserScript = WKUserScript(source: gameCacheJsString, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
             config.userContentController.addUserScript(gameCacheUserScript)

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -38,7 +38,7 @@ const endbridgeX = 765;        // where the player must jump up to cross bridge 
 const playerVelocity = 1000;   // baseline player velocity (rightward)
 // initialize task vars
 var nTrials;
-var maxTrials = nTrials;
+var maxTrials;
 var trialNo = 0;
 var trialReward1;
 var trialEffort1; var trialEffortPropMax1;
@@ -81,7 +81,7 @@ if (debug_mode) {
 
     // Check if all numbers between 0 and 23 are included
     const includedNumbers = new Set(randTrialsIdx);
-    for (let i = 0; i <= 23; i++) {
+    for (let i = 0; i <= 43; i++) {
         if (!includedNumbers.has(i)) {
             console.error(`Number ${i} is missing in randTrialsIdx.`);
         }
@@ -171,6 +171,7 @@ export default class MainTask extends BaseScene {
         // load trial info (must be done within create())
         let trials = this.cache.json.get("trials");
         nTrials = trials.reward1.length;
+        maxTrials = nTrials;
         trialsPerBlock = nTrials / nBlocks;  // blocks divide trials
         let catchIdx = trials.catchIdx ?? defaultCatchIdx;
 

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -71,22 +71,8 @@ var coinsWonThisTrial = 0;
 var smallDeviceOffset = 0;
 var consecutiveMissedTrials = 0;
 var missedTrialDialogsShown = 0;
+var randTrialsIdx;
 
-// pre-shuffle the trials here with nTrials specified in ./versionInfo.js
-var randTrialsIdx
-// check
-if (debug_mode) {
-    console.log('random trial indices check: ' + randTrialsIdx)
-    console.log('number trials: ' + Object.keys(randTrialsIdx).length)
-
-    // Check if all numbers between 0 and 23 are included
-    const includedNumbers = new Set(randTrialsIdx);
-    for (let i = 0; i <= 43; i++) {
-        if (!includedNumbers.has(i)) {
-            console.error(`Number ${i} is missing in randTrialsIdx.`);
-        }
-    };
-};
 // this function extends Phaser.Scene and includes the core logic for the game
 export default class MainTask extends BaseScene {
     constructor() {


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2644

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Now sets the `maxTrials` variable after every trial so the task now correctly exits after 44 trials rather than crashes
- Made the `GameCache` object passed into the `EEFRTViewController` optional since it was causing another crash on the iOS app, at the time of implementation it needed to be implicitly unwrapped but now it can stay optional

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On iOS:
- Run the task from start to finish, you should not encounter any crashes within the eefrt task or the iOS app itself