### PR TITLE
Store when the power-up countdown timer begins [CON-2635]

### DIFF
--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/PracticeTaskAttemptDao.kt
@@ -21,6 +21,7 @@ data class PracticeTaskAttempt(
     @ColumnInfo(name = "press_times") val pressTimes: List<Int>,
     @ColumnInfo(name = "trial_success") val trialSuccess: Int,
     @ColumnInfo(name = "max_press_count") val maxPressCount: Int,
+    @ColumnInfo(name = "power_countdown") val powerCountdown: Int,
 ) : EefrtTaskAttempt
 
 @Dao

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/TaskAttemptDto.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/TaskAttemptDto.kt
@@ -32,6 +32,7 @@ data class TaskAttempt(
     @ColumnInfo(name = "effort_time_limit") val effortTimeLimit: Int,
     @ColumnInfo(name = "recalibration") val recalibration: Int,
     @ColumnInfo(name = "threshold_max") val thresholdMax: Int,
+    @ColumnInfo(name = "power_countdown") val powerCountdown: Int,
 ): EefrtTaskAttempt
 
 @Dao

--- a/EEFRT Demo iOS/EEFRT Demo/Models/PracticeTaskResult.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/PracticeTaskResult.swift
@@ -11,8 +11,9 @@ class PracticeTaskResult: Codable {
     var pressTimes: [Int]
     var trialSuccess: Int
     var maxPressCount: Int
+    var powerCountdown: Int
 
-    init(pracTrialNo: Int, trialReward: Int, trialEffort: Int, pressCount: Int, pressTimes: [Int], trialSuccess: Int, maxPressCount: Int) {
+    init(pracTrialNo: Int, trialReward: Int, trialEffort: Int, pressCount: Int, pressTimes: [Int], trialSuccess: Int, maxPressCount: Int, powerCountdown: Int) {
         self.createdAt = Date()
         self.pracTrialNo = pracTrialNo
         self.trialReward = trialReward
@@ -21,6 +22,7 @@ class PracticeTaskResult: Codable {
         self.pressTimes = pressTimes
         self.trialSuccess = trialSuccess
         self.maxPressCount = maxPressCount
+        self.powerCountdown = powerCountdown
     }
 
     required init(from decoder: any Decoder) throws {
@@ -33,6 +35,7 @@ class PracticeTaskResult: Codable {
         self.pressTimes = try container.decode([Int].self, forKey: .pressTimes)
         self.trialSuccess = try container.decode(Int.self, forKey: .trialSuccess)
         self.maxPressCount = try container.decode(Int.self, forKey: .maxPressCount)
+        self.powerCountdown = try container.decode(Int.self, forKey: .powerCountdown)
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -45,9 +48,10 @@ class PracticeTaskResult: Codable {
         try container.encode(pressTimes, forKey: .pressTimes)
         try container.encode(trialSuccess, forKey: .trialSuccess)
         try container.encode(maxPressCount, forKey: .maxPressCount)
+        try container.encode(powerCountdown, forKey: .powerCountdown)
     }
 
     enum CodingKeys: String, CodingKey {
-        case createdAt, pracTrialNo, trialReward, trialEffort, pressCount, pressTimes, trialSuccess, maxPressCount
+        case createdAt, pracTrialNo, trialReward, trialEffort, pressCount, pressTimes, trialSuccess, maxPressCount, powerCountdown
     }
 }

--- a/EEFRT Demo iOS/EEFRT Demo/Models/TaskResult.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/TaskResult.swift
@@ -22,8 +22,9 @@ class TaskResult: Codable {
     var effortTimeLimit: Int
     var recalibration: Int
     var thresholdMax: Int
+    var powerCountdown: Int
 
-    init(trialNo: Int, trialStartTime: Int, trialReward1: Int, trialEffort1: Int, trialEffortPropMax1: Double, trialReward2: Int, trialEffort2: Int, trialEffortPropMax2: Double, choice: String, choiceRT: Int, pressCount: Int, pressTimes: [Int], trialSuccess: Int, coinsRunningTotal: Int, trialEndTime: Int, effortTimeLimit: Int, recalibration: Int, thresholdMax: Int) {
+    init(trialNo: Int, trialStartTime: Int, trialReward1: Int, trialEffort1: Int, trialEffortPropMax1: Double, trialReward2: Int, trialEffort2: Int, trialEffortPropMax2: Double, choice: String, choiceRT: Int, pressCount: Int, pressTimes: [Int], trialSuccess: Int, coinsRunningTotal: Int, trialEndTime: Int, effortTimeLimit: Int, recalibration: Int, thresholdMax: Int, powerCountdown: Int) {
         self.createdAt = Date()
         self.trialNo = trialNo
         self.trialStartTime = trialStartTime
@@ -43,6 +44,7 @@ class TaskResult: Codable {
         self.effortTimeLimit = effortTimeLimit
         self.recalibration = recalibration
         self.thresholdMax = thresholdMax
+        self.powerCountdown = powerCountdown
     }
 
     required init(from decoder: any Decoder) throws {
@@ -66,6 +68,7 @@ class TaskResult: Codable {
         self.effortTimeLimit = try container.decode(Int.self, forKey: .effortTimeLimit)
         self.recalibration = try container.decode(Int.self, forKey: .recalibration)
         self.thresholdMax = try container.decode(Int.self, forKey: .thresholdMax)
+        self.powerCountdown = try container.decode(Int.self, forKey: .powerCountdown)
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -89,9 +92,10 @@ class TaskResult: Codable {
         try container.encode(effortTimeLimit, forKey: .effortTimeLimit)
         try container.encode(recalibration, forKey: .recalibration)
         try container.encode(thresholdMax, forKey: .thresholdMax)
+        try container.encode(powerCountdown, forKey: .powerCountdown)
     }
 
     enum CodingKeys: CodingKey {
-        case createdAt, trialNo, trialStartTime, trialReward1, trialEffort1, trialEffortPropMax1, trialReward2, trialEffort2, trialEffortPropMax2, choice, choiceRT, pressCount, pressTimes, trialSuccess, coinsRunningTotal, trialEndTime, effortTimeLimit, recalibration, thresholdMax
+        case createdAt, trialNo, trialStartTime, trialReward1, trialEffort1, trialEffortPropMax1, trialReward2, trialEffort2, trialEffortPropMax2, choice, choiceRT, pressCount, pressTimes, trialSuccess, coinsRunningTotal, trialEndTime, effortTimeLimit, recalibration, thresholdMax, powerCountdown
     }
 }

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm run preview
 2. The game world was compiled using [Tiled](https://www.mapeditor.org/) using art assets by [kenney](https://kenney.nl/). Based on the [phaser3](https://phaser.io/phaser3) and [rexUI plugins](https://rexrainbow.github.io/phaser3-rex-notes/docs/site/ui-overview/).
 
 ## Response Data Structure
-Note: When 'Game Time' is mentioned it refers to the Clock used by the Phaser Game Engine which counts in milliseconds from the time the scene is originally created. The scene is restarted whenever a new trial occurs but will retain the same Clock for the scene and thus the the will continue to increment without resetting untill a new scene is raeached.
+Note: When 'Game Time' is mentioned it refers to the Clock used by the Phaser Game Engine which counts in milliseconds from the time the scene is originally created. The scene is restarted whenever a new trial occurs but will retain the same Clock for the scene and thus the the will continue to increment without resetting untill a new scene is reached.
 
 ### PracticeTaskAttempt
 | Field | Type | Description |
@@ -73,6 +73,7 @@ Note: When 'Game Time' is mentioned it refers to the Clock used by the Phaser Ga
 | `trialSuccess` | Boolean | Whether or not the user reached the effort threshold current trial (0 or 1). |
 | `maxPressCount` | Number | The maximum number of times the power button was pressed during the power up animation. |
 | `createdAt` | Date | A timestamp measured in seconds since January 1, 1970 (UTC), of when each trial (practice and main) are saved to the local database. |
+| `powerCountdown` | Number | The Game Time at which the power-up countdown timer begins to tick down. |
 
 ### TaskAttempt
 | Field | Type | Description |
@@ -96,3 +97,4 @@ Note: When 'Game Time' is mentioned it refers to the Clock used by the Phaser Ga
 | `recalibration` | Boolean | Whether or not the `thresholdMax` was adjusted due to the user reaching a new maximum number of presses (0 or 1). |
 | `thresholdMax` | Number | The maximum number of taps the user has achieved so far across all completed trials, include the calibration trials. |
 | `createdAt` | Date | A timestamp measured in seconds since January 1, 1970 (UTC). |
+| `powerCountdown` | Number | The Game Time at which the power-up countdown timer begins to tick down. |

--- a/public/src/elements/CountdownPanel.js
+++ b/public/src/elements/CountdownPanel.js
@@ -1,6 +1,8 @@
 import eventsCenter from '../eventsCenter.js'
 import { timeout } from '../versionInfo.js';
 
+export const POWER_COUNTDOWN_KEY = 'powerCountdown';
+
 export default class CountdownPanel {
     constructor(scene, x, y, duration = timeout, timeoutKey, startImmediately = true) {
         this.scene = scene;
@@ -77,6 +79,8 @@ export default class CountdownPanel {
     
     startCountdown() {
         const updateInterval = 50; // Update every 50ms for smooth animation
+
+        eventsCenter.emit(POWER_COUNTDOWN_KEY, Math.round(this.scene.time.now));
         
         this.timer = this.scene.time.addEvent({
             delay: updateInterval,

--- a/public/src/elements/PowerPanel.js
+++ b/public/src/elements/PowerPanel.js
@@ -173,9 +173,7 @@ export default class PowerPanel {
                         this.powerButtonText.setColor('#FFFFFF');
                         this.state = powerPanelState.power;
                         eventsCenter.emit('powerStatePassed');
-                        setTimeout(() => { 
-                            this.countdownPanel.startCountdown();
-                        }, 500)
+                        this.countdownPanel.startCountdown();
                         break;
                     
                     case powerPanelState.power:

--- a/public/src/embedContext/PracticeTaskAttempt.js
+++ b/public/src/embedContext/PracticeTaskAttempt.js
@@ -1,5 +1,5 @@
 export default class PracticeTaskAttempt {
-    constructor(pracTrial, selectedReward, selectedEffort, pressCount, pressTimes, trialSuccess, maxPressCount) {
+    constructor(pracTrial, selectedReward, selectedEffort, pressCount, pressTimes, trialSuccess, maxPressCount, powerCountdown) {
         this.pracTrialNo = pracTrial
         this.trialReward = selectedReward
         this.trialEffort = selectedEffort
@@ -7,6 +7,7 @@ export default class PracticeTaskAttempt {
         this.pressTimes = pressTimes
         this.trialSuccess = trialSuccess
         this.maxPressCount = maxPressCount
+        this.powerCountdown = powerCountdown
     }
 
     stringify() {

--- a/public/src/embedContext/TaskAttempt.js
+++ b/public/src/embedContext/TaskAttempt.js
@@ -1,5 +1,5 @@
 export default class TaskAttempt {
-    constructor(trialNo, trialStartTime, trialReward1, trialEffort1, trialEffortPropMax1, trialReward2, trialEffort2, trialEffortPropMax2, choice, choiceRT, pressCount, pressTimes, trialSuccess, coinsRunningTotal, trialEndTime, effortTimeLimit, recalibration, thresholdMax) {
+    constructor(trialNo, trialStartTime, trialReward1, trialEffort1, trialEffortPropMax1, trialReward2, trialEffort2, trialEffortPropMax2, choice, choiceRT, pressCount, pressTimes, trialSuccess, coinsRunningTotal, trialEndTime, effortTimeLimit, recalibration, thresholdMax, powerCountdown) {
         this.trialNo = trialNo;
         this.trialStartTime = trialStartTime;
         this.trialReward1 = trialReward1;
@@ -18,6 +18,7 @@ export default class TaskAttempt {
         this.effortTimeLimit = effortTimeLimit;
         this.recalibration = recalibration;
         this.thresholdMax = thresholdMax;
+        this.powerCountdown = powerCountdown;
     }
 
     stringify() {

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -24,6 +24,7 @@ import PowerPanel from "../elements/PowerPanel.js";
 import { POWER_UP_COMPLETE_KEY } from "../elements/PowerPanel.js";
 import GameCache from "../embedContext/GameCache.js";
 import TaskAttempt from "../embedContext/TaskAttempt.js";
+import { POWER_COUNTDOWN_KEY } from "../elements/CountdownPanel.js";
 
 // initialize all the global vars (must be a better way of doing this...)
 var gameHeight; 
@@ -72,6 +73,7 @@ var smallDeviceOffset = 0;
 var consecutiveMissedTrials = 0;
 var missedTrialDialogsShown = 0;
 var randTrialsIdx;
+var powerCountdown;
 
 // this function extends Phaser.Scene and includes the core logic for the game
 export default class MainTask extends BaseScene {
@@ -328,6 +330,8 @@ export default class MainTask extends BaseScene {
                           function(){eventsCenter.emit('trialEndHit');}, null, this); // once the player has collided with invisible trial end point, emit event
         // once this event us detected, perform the function trialEnd (only once)
         eventsCenter.once('trialEndHit', trialEnd, this);
+
+        eventsCenter.once(POWER_COUNTDOWN_KEY, storeCountdownStarted, this);
         
         // // 3. if desired, add listener functions to pause game when focus taken away
         // // from game browser tab/window [necessary for mobile devices]
@@ -693,7 +697,8 @@ var trialEnd = function () {
         trialEndTime,
         effortTime,
         recalibration,
-        thresholdMax
+        thresholdMax,
+        powerCountdown
     );
 
     // save the data in a registry for later retrieval
@@ -912,4 +917,8 @@ var showBottomScreenPanel = function(context, titleText, subtitleText, bottomBut
         repeat: 0,      
         yoyo: false
     });    
+}
+
+var storeCountdownStarted = function(startTime) {
+    powerCountdown = startTime;
 }

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -17,6 +17,7 @@ import { effortTime, pracTrialEfforts, pracTrialRewards, timeout } from "../vers
 import Message from "../elements/message.js";
 import GameCache from "../embedContext/GameCache.js";
 import PracticeTaskAttempt from "../embedContext/PracticeTaskAttempt.js";
+import { POWER_COUNTDOWN_KEY } from "../elements/CountdownPanel.js";
 
 // initialize some global vars
 var gameHeight;
@@ -60,6 +61,8 @@ const PRACTICE_CHOICE_KEY = 'practiceChoiceComplete';
 
 var routeSelectionTransitionTimer;
 var smallDeviceOffset = 0;
+
+var powerCountdown;
 
 // this function extends Phaser.Scene and includes the core logic for the game
 export default class PracticeTask extends BaseScene {
@@ -246,6 +249,8 @@ export default class PracticeTask extends BaseScene {
             function () { eventsCenter.emit('practiceTrialEndHit'); }, null, this); // once the player has collided with invisible trial end point, emit event
         // once this event us detected, perform the function trialEnd (only once)
         eventsCenter.once('practiceTrialEndHit', pracTrialEnd, this);
+
+        eventsCenter.once(POWER_COUNTDOWN_KEY, storeCountdownStarted, this);
 
         // // 3. if desired, add listener functions to pause game when focus taken away
         // // from game browser tab/window [necessary for mobile devices]
@@ -649,7 +654,8 @@ var pracTrialEnd = function () {
         pressCount,
         pressTimes,
         trialSuccess,
-        this.registry.get('maxPressCount')
+        this.registry.get('maxPressCount'),
+        powerCountdown
     );
     this.registry.set("pracTrial"+pracTrial, practiceTaskAttempt);
     // save data
@@ -681,3 +687,7 @@ var onejump = function () {
     let jumpAnimDuration = 1100;
     this.time.delayedCall(jumpAnimDuration, () => { this.player.sprite.setVelocityX(playerVelocity/5); }, null, this);
 };
+
+var storeCountdownStarted = function(startTime) {
+    powerCountdown = startTime;
+}


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2635

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Removed the 500ms delay on the countdown timer during the practice tasks
- Updated the `PracticeTaskAttempt` and `TaskAttempt` classes to include the new `powerCountdown` field
- Updated the README to include the new `powerCountdown` field in the data dictionaries  

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On both iOS and Android
1) Uninstall the apps on both platforms
2) Do a clean of both the project build folders on each platform
3) Re-install and run the apps
4) Complete the practice trials, making sure to attempt to spam the power button on at least once from the ready -> power state
5) Complete some main trials
6) View the event logs for both the practice and main trials, you'll see the new `powerCountdown` field
7) Ensure that the value for `powerCountdown` is less than the first value in `pressTimes` in the practice trials (and the main trials for good measure as well)

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->

Android practice event log | android main event log | iOS practice event log | iOS main event log |
| --- | --- | --- | --- |
| <img width="365" alt="image" src="https://github.com/user-attachments/assets/2ba1ed55-9b21-4a13-8339-2f7e2051cdcc" /> | <img width="364" alt="image" src="https://github.com/user-attachments/assets/87d9db55-c60a-453e-bccb-d8290eeb4edb" /> | <img width="364" alt="image" src="https://github.com/user-attachments/assets/bcadf4df-c015-443a-8bf9-4864ac008173" /> | <img width="366" alt="image" src="https://github.com/user-attachments/assets/e0012ac8-c765-4269-8b2c-60e5249b2229" /> |

