### PR TITLE
Fix issue with incorrect game config height

### DIFF
--- a/public/src/scenes/startTaskScene.js
+++ b/public/src/scenes/startTaskScene.js
@@ -13,8 +13,8 @@ export default class StartTaskScene extends BaseScene {
     }
     
     create() {
-        const width = this.game.config.width;
-        const height = this.game.config.height;
+        const width = this.sys.game.config.width;
+        const height = this.sys.game.config.height;
         const maxWidth = width - 50; // Width - padding 25px left and right
         const panelHeight = height - 100;
         const panelX = width / 2;

--- a/public/src/task.js
+++ b/public/src/task.js
@@ -13,36 +13,39 @@ const scenes = [
 // Prepend PracticeTask if runPractice is true
 if (runPractice) { scenes.unshift(new PracticeTask()) };
 
-// create the phaser game, based on the following config
-const config = {
-    type: Phaser.Scale.AUTO,           // rendering: webGL if available, otherwise canvas
-    width: window.innerWidth,
-    height: window.innerHeight,
-    physics: {
-        default: 'arcade',       // add light-weight physics to our world
-        arcade: {
-            gravity: { y: 600 }, // need some gravity for a side-scrolling platformer
-            debug: false         // TRUE for debugging game physics, FALSE for deployment
+const config = function() {
+    // Create a config object when requested, rather than when this JS file is loaded.
+    // This ensures its more likely that the height and width is correct.
+    return {
+        type: Phaser.AUTO,           // rendering: webGL if available, otherwise canvas
+        width: window.innerWidth,
+        height: window.innerHeight,
+        physics: {
+            default: 'arcade',       // add light-weight physics to our world
+            arcade: {
+                gravity: { y: 600 }, // need some gravity for a side-scrolling platformer
+                debug: false         // TRUE for debugging game physics, FALSE for deployment
+            }
+        },
+        parent: 'game-container',    // ID of the DOM element to add the canvas to
+        dom: {
+            createContainer: true    // to allow text input DOM element
+        },
+        backgroundColor: "#CFEFFC",  // pale blue sky color [black="#222222"],
+        scene: scenes,         // construct the experiment from componenent scenes
+        plugins: {
+            scene: [{
+                key: 'rexUI',
+                plugin: rexuiplugin,  // load the rexUI plugins here for all scenes
+                mapping: 'rexUI'
+            }]
+        },
+        scale: {
+            mode: Phaser.Scale.RESIZE,
+            autoCenter: Phaser.Scale.CENTER_BOTH
         }
-    },
-    parent: 'game-container',    // ID of the DOM element to add the canvas to
-    dom: {
-        createContainer: true    // to allow text input DOM element
-    },
-    backgroundColor: "#CFEFFC",  // pale blue sky color [black="#222222"],
-    scene: scenes,         // construct the experiment from componenent scenes
-    plugins: {
-        scene: [{
-            key: 'rexUI',
-            plugin: rexuiplugin,  // load the rexUI plugins here for all scenes
-            mapping: 'rexUI'
-        }]
-    },
-    scale: {
-        mode: Phaser.Scale.RESIZE,
-        autoCenter: Phaser.Scale.CENTER_BOTH
-    }
-};
+    };
+}
 
 const loadFont = async function(name, url, weight) {
     // Fetch the local file and get the object URL that is tied to the document (DOM), i.e. http://localhost:3000/<uuid>.
@@ -62,6 +65,16 @@ export function runTask() {
         loadFont('DMSans', './src/assets/fonts/DMSans-Bold.ttf', 700),
         loadFont('DMSans', './src/assets/fonts/DMSans-Regular.ttf', 400)
     ]).then(() => {
-        new Phaser.Game(config);
+        window.game = new Phaser.Game(config());
     });
 };
+
+// Update the game config height and width used in the scenes.
+window.addEventListener('resize', () => {
+    if (window.game) {
+        window.game.config.height = window.innerHeight;
+        window.game.config.width = window.innerWidth;
+    } else {
+        console.warn("Game not initialized yet, resizing will not work.");
+    }
+});


### PR DESCRIPTION
## Why did you make these changes?

https://deakinuniversity.atlassian.net/browse/CON-2645

## What changes did you make?

1. Fixed up the config [`type`](https://docs.phaser.io/api-documentation/typedef/types-core#static-gameconfig) which should be `Phaser.AUTO` (which is the default value), so that the game either chooses WebGL or canvas.
2. Wrap the `config` object in a function so that it's constructed when the function is called. This ensures the height and width is more likely to be correct as the resize function is not always called.
3. Assign the Phaser game object to `window.game` so that we can reference it from the `window` object throughout the webpage.
4. Reference `this.sys.game` in the start task scene matching the other scenes.
5. Define a `resize` event listener which updates the `config.height` and `width` with a new `window.innerHeight` or `innerWidth`. This resize function is (sometimes) called by the Safari webkit after loading the page. For unknown reasons the Safari webkit does this both in the simulator and physical device. Very annoying.

So combining these fixes seem to have resolved the issue. I was never able to replicate the issue on our practice or main task. And these changes didn't negative impact them either.

## Testing

1. Change `runPractice` to false to immediately launch the `startTaskScene`.
2. Start the game but stay on that scene.
3. Open desktop Safari > Develop > Simulator > Inspect Application to inspect the `index.html`
4. Use the refresh button in the developer tools to force a refresh of the game. Do this often enough to see if you ever get that wrong size issue – hopefully you should not.

That same refresh technique doesn't work via Android. It just refreshes within Chrome, not in the emulator. But also tested there to see nothing negative has happened.