### PR TITLE
Save the trial data immediately after the power up animation [CON-2637]

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Note: When 'Game Time' is mentioned it refers to the Clock used by the Phaser Ga
 | `pressTimes` | Array[Number] | An array containing each time the power button was pressed curing the power up animation. Individual press counts are derived from the current Game Time at which the tap occured. |
 | `trialSuccess` | Boolean | Whether or not the user reached the effort threshold current trial (0 or 1). |
 | `coinsRunningTotal` | Float | The total number of coins the user has earned so far in the task across all completed trials. |
-| `trialEndTime` | Number | The Game Time at which the current trial ended. the practice task ended. |
+| `trialEndTime` | Number | The Game Time at which the current trial is marked as completed, either that be at the end of the power-up animation or as soon as the route selector times out. |
 | `effortTimeLimit` | Number | The amount of time in milliseconds given to the user to reach the effort threshold for the current trial. |
 | `recalibration` | Boolean | Whether or not the `thresholdMax` was adjusted due to the user reaching a new maximum number of presses (0 or 1). |
 | `thresholdMax` | Number | The maximum number of taps the user has achieved so far across all completed trials, include the calibration trials. |

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -861,6 +861,17 @@ var saveData = function(context) {
         thresholdMax = maxPressCount // do not adjust thresholdMax 
     };
 
+    // as a fallback for the case where the player misses the coins, we will add the coins regardless if the player touches them or not
+    if (trialSuccess && choice == 'route 1') {
+        coinsWonThisTrial = trialReward1;
+        nCoins += coinsWonThisTrial;
+    } else if (trialSuccess && choice == 'route 2') {
+        coinsWonThisTrial = trialReward2;
+        nCoins += coinsWonThisTrial;
+    } else {
+        coinsWonThisTrial = 0;
+    }
+
     if (choice == 'timeout') {
         // if the choice was a timeout then reset all the relevant variables so the payload doesn't retain the previous trial's data
         trialEffortPropChosen = 0;
@@ -904,17 +915,6 @@ var saveData = function(context) {
     console.log(context.registry.get("trial" + trialNo));
     // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
     //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]
-
-    // as a fallback for the case where the player misses the coins, we will add the coins regardless if the player touches them or not
-    if (trialSuccess && choice == 'route 1') {
-        coinsWonThisTrial = trialReward1;
-        nCoins += coinsWonThisTrial;
-    } else if (trialSuccess && choice == 'route 2') {
-        coinsWonThisTrial = trialReward2;
-        nCoins += coinsWonThisTrial;
-    } else {
-        coinsWonThisTrial = 0;
-    }
 
     // save the current coin choice to the cache by adding on to the previous dictionary if present
     let coinChoices = GameCache.cache?.trialResults ?? {};

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -911,11 +911,9 @@ var saveData = function(context) {
     // save the data in a registry for later retrieval
     context.registry.set("trial" + trialNo, taskAttempt);
 
-    // save data
+    // inform the native apps of the trial result
     EmbedContext.sendMessage("trialResult", taskAttempt.stringify());
     console.log(context.registry.get("trial" + trialNo));
-    // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
-    //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]
 
     // save the current coin choice to the cache by adding on to the previous dictionary if present
     let coinChoices = GameCache.cache?.trialResults ?? {};

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -904,7 +904,8 @@ var saveData = function(context) {
         trialEndTime,
         effortTime,
         recalibration,
-        thresholdMax
+        thresholdMax,
+        powerCountdown
     );
 
     // save the data in a registry for later retrieval

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -602,134 +602,13 @@ var effortOutcome = function() {
                             },                         
                             callbackScope: this});
     }
+
+    // save the data immediately after powerup/timeout in the event the walking animation gets interrupted before it completes
+    saveData(this);
 };
 
 // 4. When player hits end of scene, save trial data and move on to the next trial (reload the scene)
 var trialEnd = function () {
-    // get trial end time
-    trialEndTime = Math.round(this.time.now);
-
-    // n.b. nCalibrates now set in versionInfo.js
-    // we completed the practice, but might be loading back from a cached run so we've already calibrated
-
-    var updatedNumCalibrates = nCalibrates;
-    if (GameCache.cache?.practiceComplete == true && runPractice) {
-        updatedNumCalibrates = 0;
-    }
-
-    if (trialNo < updatedNumCalibrates) {
-        // get variables to use 
-        pressTimes = this.registry.get('pressTimes');
-        pressCount = this.registry.get('pressCount');
-        pressStartTime = pressTimes[0]; // pressStartTime is the first pressTime
-        pressEndTime = pressTimes[pressTimes.length - 1]; // pressEndTime is the last pressTime
-
-        // get level of effort chosen
-        if (choice == 'route 1') {
-            trialEffortPropChosen = trialEffortPropMax1;
-            trialEffort = trialEffort1;
-        }
-        else {
-            trialEffortPropChosen = trialEffortPropMax2; // else they chose route 2
-            trialEffort = trialEffort2;
-        }
-        // for success trials if pressTime was faster than expected given the effort level, recalibrate
-        if (pressCount >= trialEffort &&
-            ((pressEndTime - pressStartTime) < (effortTime * trialEffortPropChosen))) {
-            // calculate their new 100% threshold
-            var threshold = Math.round(((pressCount / ((pressEndTime - pressStartTime) / 1000)) * (effortTime / 1000)))
-            // if threshold is greater than the original maxPress: thresholdMax is updated 
-            if (threshold > maxPressCount) {
-                thresholdMax = threshold
-                var recalibration = 1;
-            }
-            else {
-                // continue with thresholdMax at maxPressCount 
-                var recalibration = 0;
-                thresholdMax = maxPressCount;
-            }
-        }
-        else {// the trial wasn't successful or did not need recalibration: 
-            var recalibration = 0; // record recalibration didn't occur
-            // also keep thresholdMax at maxPressCount
-            thresholdMax = maxPressCount
-
-        }
-        // save thresholdMax
-        this.registry.set("thresholdMax", { thresholdMax });
-        // save it in its own document for easy retrieval later 
-        // saveThresholdMax(this.registry.get("thresholdMax"));        // [for firebase]
-    }
-    else { // if we are past the first calibration trials 
-        var recalibration = 0; // record recalibration didn't occur
-        thresholdMax = maxPressCount // do not adjust thresholdMax 
-    };
-
-    if (choice == 'timeout') {
-        // if the choice was a timeout then reset all the relevant variables so the payload doesn't retain the previous trial's data
-        trialEffortPropChosen = 0;
-        trialEffort = 0;
-        choiceRT = 0;
-        pressCount = 0;
-        pressTimes = [];
-        trialSuccess = 0;
-        pressStartTime = 0;
-        pressEndTime = 0;
-        coinsWonThisTrial = 0;
-    }
-
-    // set data to be saved into registry
-    let taskAttempt = new TaskAttempt(
-        trialNo,
-        trialStartTime,
-        trialReward1,
-        trialEffort1,
-        trialEffortPropMax1,
-        trialReward2,
-        trialEffort2,
-        trialEffortPropMax2,
-        choice,
-        choiceRT,
-        pressCount,
-        pressTimes,
-        trialSuccess,
-        nCoins,
-        trialEndTime,
-        effortTime,
-        recalibration,
-        thresholdMax,
-        powerCountdown
-    );
-
-    // save the data in a registry for later retrieval
-    this.registry.set("trial" + trialNo, taskAttempt);
-
-    // save data
-    EmbedContext.sendMessage("trialResult", taskAttempt.stringify());
-    console.log(this.registry.get("trial" + trialNo));
-    // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
-    //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]
-    
-    // as a fallback for the case where the player misses the coins, we will add the coins regardless if the player touches them or not
-    if (trialSuccess && choice == 'route 1') {
-        coinsWonThisTrial = trialReward1;
-        nCoins += coinsWonThisTrial;
-    } else if (trialSuccess && choice == 'route 2') {
-        coinsWonThisTrial = trialReward2;
-        nCoins += coinsWonThisTrial;
-    } else {
-        coinsWonThisTrial = 0;
-    }
-
-    // save the current coin choice to the cache by adding on to the previous dictionary if present
-    let coinChoices = GameCache.cache?.trialResults ?? {};
-    coinChoices['trial' + trialNo] = trialSuccess ? coinsWonThisTrial : 0;
-
-    // notify the native apps of what the current game state is so they can cache it
-    let currentGameState = new GameCache(true, trialNo + 1, maxPressCount, nCoins, coinChoices, randTrialsIdx, this.trialSequenceFile);
-    GameCache.cache = currentGameState;
-    EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
-
     // if the user has been shown the 'Are you still there?' message and they trigger it again, kick them out of the task
     let isLastTrial = trialNo == nTrials - 1;
     let missedTrialDialogShownLimitReached = (missedTrialDialogsShown >= missedTrialDialogLimit) && missedTrialDialogLimit > 0; // ensure that a limit of 0 allows the dialog to be shown as many times as needed
@@ -921,4 +800,128 @@ var showBottomScreenPanel = function(context, titleText, subtitleText, bottomBut
 
 var storeCountdownStarted = function(startTime) {
     powerCountdown = startTime;
+}
+
+var saveData = function(context) {
+    // get trial end time
+    trialEndTime = Math.round(context.time.now);
+
+    // n.b. nCalibrates now set in versionInfo.js
+    // we completed the practice, but might be loading back from a cached run so we've already calibrated
+    var updatedNumCalibrates = nCalibrates;
+    if (GameCache.cache?.practiceComplete == true && runPractice) {
+        updatedNumCalibrates = 0;
+    }
+
+    if (trialNo < updatedNumCalibrates) {
+        // get variables to use 
+        pressTimes = context.registry.get('pressTimes');
+        pressCount = context.registry.get('pressCount');
+        pressStartTime = pressTimes[0]; // pressStartTime is the first pressTime
+        pressEndTime = pressTimes[pressTimes.length - 1]; // pressEndTime is the last pressTime
+
+        // get level of effort chosen
+        if (choice == 'route 1') {
+            trialEffortPropChosen = trialEffortPropMax1;
+            trialEffort = trialEffort1;
+        }
+        else {
+            trialEffortPropChosen = trialEffortPropMax2; // else they chose route 2
+            trialEffort = trialEffort2;
+        }
+        // for success trials if pressTime was faster than expected given the effort level, recalibrate
+        if (pressCount >= trialEffort &&
+            ((pressEndTime - pressStartTime) < (effortTime * trialEffortPropChosen))) {
+            // calculate their new 100% threshold
+            var threshold = Math.round(((pressCount / ((pressEndTime - pressStartTime) / 1000)) * (effortTime / 1000)))
+            // if threshold is greater than the original maxPress: thresholdMax is updated 
+            if (threshold > maxPressCount) {
+                thresholdMax = threshold
+                var recalibration = 1;
+            }
+            else {
+                // continue with thresholdMax at maxPressCount 
+                var recalibration = 0;
+                thresholdMax = maxPressCount;
+            }
+        }
+        else {// the trial wasn't successful or did not need recalibration: 
+            var recalibration = 0; // record recalibration didn't occur
+            // also keep thresholdMax at maxPressCount
+            thresholdMax = maxPressCount
+
+        }
+        // save thresholdMax
+        context.registry.set("thresholdMax", { thresholdMax });
+        // save it in its own document for easy retrieval later 
+        // saveThresholdMax(this.registry.get("thresholdMax"));        // [for firebase]
+    }
+    else { // if we are past the first calibration trials 
+        var recalibration = 0; // record recalibration didn't occur
+        thresholdMax = maxPressCount // do not adjust thresholdMax 
+    };
+
+    if (choice == 'timeout') {
+        // if the choice was a timeout then reset all the relevant variables so the payload doesn't retain the previous trial's data
+        trialEffortPropChosen = 0;
+        trialEffort = 0;
+        choiceRT = 0;
+        pressCount = 0;
+        pressTimes = [];
+        trialSuccess = 0;
+        pressStartTime = 0;
+        pressEndTime = 0;
+        coinsWonThisTrial = 0;
+    }
+
+    // set data to be saved into registry
+    let taskAttempt = new TaskAttempt(
+        trialNo,
+        trialStartTime,
+        trialReward1,
+        trialEffort1,
+        trialEffortPropMax1,
+        trialReward2,
+        trialEffort2,
+        trialEffortPropMax2,
+        choice,
+        choiceRT,
+        pressCount,
+        pressTimes,
+        trialSuccess,
+        nCoins,
+        trialEndTime,
+        effortTime,
+        recalibration,
+        thresholdMax
+    );
+
+    // save the data in a registry for later retrieval
+    context.registry.set("trial" + trialNo, taskAttempt);
+
+    // save data
+    EmbedContext.sendMessage("trialResult", taskAttempt.stringify());
+    console.log(context.registry.get("trial" + trialNo));
+    // saveTaskData(trial, this.registry.get(`trial${trial}`));        // [for firebase]
+    //saveTrialDataPav(this.registry.get(`trial${trial}`));         // [for Pavlovia deployment only]
+
+    // as a fallback for the case where the player misses the coins, we will add the coins regardless if the player touches them or not
+    if (trialSuccess && choice == 'route 1') {
+        coinsWonThisTrial = trialReward1;
+        nCoins += coinsWonThisTrial;
+    } else if (trialSuccess && choice == 'route 2') {
+        coinsWonThisTrial = trialReward2;
+        nCoins += coinsWonThisTrial;
+    } else {
+        coinsWonThisTrial = 0;
+    }
+
+    // save the current coin choice to the cache by adding on to the previous dictionary if present
+    let coinChoices = GameCache.cache?.trialResults ?? {};
+    coinChoices['trial' + trialNo] = trialSuccess ? coinsWonThisTrial : 0;
+
+    // notify the native apps of what the current game state is so they can cache it
+    let currentGameState = new GameCache(true, trialNo + 1, maxPressCount, nCoins, coinChoices, randTrialsIdx, context.trialSequenceFile);
+    GameCache.cache = currentGameState;
+    EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
 }


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2637

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- The game cache and the trial data is updated/saved immediately after the power up animation occurs or when the user times out during route selection, reducing the possibility that a rogue interruption prevents them from losing progress on that individual trial
- Updated the readme data dictionary with the updated `trialEndTime` definition

## Open questions
- Should the `trialEndTime` value in the `TaskResult` object be recorded soon as the power up animation is complete/times out? Or should it remain at the end of the walking animation? This PR has updated it to update along with the rest of the trial data after the power up/timeout and the README has been adjusted accordingly. I figured i'd raise incase they need that specific data point of exactly when the trial completely ended.

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1) Run the task and progress past the practice trials
2) Run through a few main trials, watching the logs coming back from the EEFRT task to ensure the game cache is being updated with the right trial number and isn't skipping on individual trial results
3) Exit and re-enter the task and complete a trial.
4) Compare the logs from the most recent trial to the other trials, double check to make sure individual trials/results aren't being skipped over