### PR TITLE
Add in the interruptions handling logic [CON-2652]

### DIFF
--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
@@ -6,6 +6,7 @@ import hu.autsoft.krate.booleanPref
 import hu.autsoft.krate.default.withDefault
 import hu.autsoft.krate.intPref
 import hu.autsoft.krate.kotlinx.kotlinxPref
+import hu.autsoft.krate.longPref
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -14,11 +15,11 @@ data class GameCache(
     val trialNumber: Int = 0,
     var maxPressCount: Int = 0,
     val coinRunningTotal: Int = 0,
-    val trialResults: Map<String, Int> = emptyMap<String, Int>(),
+    val trialResults: Map<String, Int> = emptyMap(),
     val randTrialsIdx: List<Int>? = null,
     val trialSeqFilename: String? = null,
-    var calibrationComplete: Boolean = false
-)
+    var calibrationComplete: Boolean = false,
+    var interruptionTimestamp: Long? = null
 ) {
     fun isResumeTrialAvailable(): Boolean {
         return practiceComplete || trialNumber > 0

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
@@ -19,6 +19,11 @@ data class GameCache(
     val trialSeqFilename: String? = null,
     var calibrationComplete: Boolean = false
 )
+) {
+    fun isResumeTrialAvailable(): Boolean {
+        return practiceComplete || trialNumber > 0
+    }
+}
 
 class GameStorage(context: Context) : SimpleKrate(context) {
     var cachedGameState: GameCache? by kotlinxPref<GameCache>("cachedGameState").withDefault(

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -4,32 +4,41 @@ import ai.a2i2.conductor.effrtdemoandroid.persistence.GameCache
 import ai.a2i2.conductor.effrtdemoandroid.persistence.GameStorage
 import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
+import ai.a2i2.conductor.effrtdemoandroid.ui.data.CloseMessage
 import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtScreenViewModel
 import android.annotation.SuppressLint
-import android.app.AlertDialog
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.Window
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.webkit.WebViewAssetLoader
 import androidx.webkit.WebViewAssetLoader.AssetsPathHandler
 import androidx.webkit.WebViewAssetLoader.DEFAULT_DOMAIN
@@ -39,6 +48,7 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.json.JSONException
 import org.json.JSONObject
+import java.time.Instant
 import java.util.Date
 
 @SuppressLint("SetJavaScriptEnabled")
@@ -50,12 +60,30 @@ fun EefrtScreen(
     val exitRequested = remember { mutableStateOf(false) }
     val webView = remember { mutableStateOf<WebView?>(null) }
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     val insets = WindowInsets.statusBars.asPaddingValues()
     val topPaddingDp = insets.calculateTopPadding().value.toInt()
     // On first composition the value is 0, so we need to wait for the second composition to get
     // the actual value before we continue to render the WebView.
     if (topPaddingDp <= 0) return
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> onTaskResume(viewModel, context, webView.value)
+                Lifecycle.Event.ON_PAUSE -> onTaskPause(viewModel)
+                else -> Unit
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            viewModel.interruptionTimestamp.value = null
+        }
+    }
 
     Box(contentAlignment = Alignment.Center) {
         AndroidView(
@@ -92,13 +120,16 @@ fun EefrtScreen(
 
                             // inject the stored calibrationComplete and calibratedMaxPressCount values into the cache
                             val gameStorage = GameStorage(context)
-                            var cache = gameStorage.cachedGameState ?: GameCache()
+                            val cache = gameStorage.cachedGameState ?: GameCache()
                             if (gameStorage.calibrationComplete == true && gameStorage.calibratedMaxPressCount != null) {
                                 cache.calibrationComplete = true
                                 cache.maxPressCount = gameStorage.calibratedMaxPressCount!!
                             }
 
-                            val cacheJson = Json.encodeToString(cache)
+                            val json = Json {
+                                encodeDefaults = true
+                            }
+                            val cacheJson = json.encodeToString(cache)
                             val jsString = "window.setupGameWithCache(${cacheJson});"
                             evaluateJavascript(jsString, null)
                         }
@@ -129,14 +160,14 @@ fun EefrtScreen(
                 "You have not completed enough rounds to earn the bonus payment and will lose your progress."
 
             AlertDialog(
-                onDismissRequest = { viewModel.showExitDialog.value = false },
+                onDismissRequest = { viewModel.dismissCloseDialog() },
                 title = { Text("Quit task?") },
                 text = { Text(message) },
                 confirmButton = {
                     TextButton(
                         onClick = {
-                            viewModel.showExitDialog.value = false
-
+                            viewModel.onConfirmCloseDialog(TAG)
+                            exitRequested.value = true
                             dismiss(onBack)
                         }
                     ) {
@@ -144,7 +175,7 @@ fun EefrtScreen(
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = { viewModel.showExitDialog.value = false }) {
+                    TextButton(onClick = { viewModel.dismissCloseDialog() }) {
                         Text("Cancel")
                     }
                 }
@@ -155,12 +186,43 @@ fun EefrtScreen(
 
 private const val TAG = "EefrtScreen"
 
+private fun onTaskPause(viewModel: EefrtScreenViewModel) {
+    // ensure this value is only updated once, while we are actively using the app
+    if (viewModel.interruptionTimestamp.value == null) {
+        viewModel.interruptionTimestamp.value = Instant.now().toEpochMilli()
+    }
+}
+
+private fun onTaskResume(viewModel: EefrtScreenViewModel, context: Context, webView: WebView?) {
+    val cache = viewModel.getCurrentGameState(context)
+        ?.copy() // ensure we get a copy of the game state so the changes we make to the timestamp arent persisted
+    val interruptionTimestamp = viewModel.interruptionTimestamp.value
+
+    if (cache == null || interruptionTimestamp == null || webView == null) {
+        return
+    }
+    // append the interruption timestamp to the cache
+    cache.interruptionTimestamp = interruptionTimestamp
+
+    // encode the cache and pass it along to the game
+    val json = Json  {
+        encodeDefaults = true
+    }
+    val cacheJson = json.encodeToString(cache)
+    val jsString = "window.setupGameWithCache(${cacheJson});"
+    webView.evaluateJavascript(jsString, null)
+
+    // reset the interruptionTimestamp value
+    cache.interruptionTimestamp = null
+    viewModel.interruptionTimestamp.value = null
+}
+
 private fun handleMessage(
     message: String,
     onBack: () -> Unit,
     exitRequested: MutableState<Boolean>,
     viewModel: EefrtScreenViewModel,
-    context: Context
+    context: Context,
 ) {
     try {
         val obj = JSONObject(message)
@@ -177,7 +239,8 @@ private fun handleMessage(
                     If they are still in the practice trials, just exit the task.
                     We also want to not show the exit dialog if they are shown the Times Up message.
 
-                    Messages from this key will contain an Boolean value which determines if we show the exit dialog or not
+                    We may also be requested to exit the task if a significant interruption has occurred and will need to determine if the
+                    task attempt count should be incremented or not as well.
                  */
 
                 if (obj.isNull("message")) {
@@ -190,9 +253,29 @@ private fun handleMessage(
                     return
                 }
 
-                val shouldShowDialog = obj.getBoolean("message")
-                if (shouldShowDialog) {
-                    showDialogMessage(viewModel)
+                // decode the message from the JS side
+                val body = obj.getString("message")
+                val gson = Gson()
+                val closeMessage = gson.fromJson(body, CloseMessage::class.java)
+
+                // ensure its only incremented if the game is closed, the user has the option to cancel closing the task via the dialog
+                if (!closeMessage.shouldShowExitDialog && closeMessage.incrementAttemptCount) {
+                    Log.d(
+                        TAG,
+                        "Incremented attempt count"
+                    )
+                }
+
+                // ensure the game data is reset if we've actually closed the task, similar scenario to the shouldShowExitDialog
+                if (!closeMessage.shouldShowExitDialog && closeMessage.taskRequiresRestart) {
+                    Log.d(
+                        TAG,
+                        "Task will be restarted on next load"
+                    )
+                }
+
+                if (closeMessage.shouldShowExitDialog) {
+                    viewModel.showCloseDialog(closeMessage)
                 } else {
                     exitRequested.value = true
                     dismiss(onBack)
@@ -238,6 +321,7 @@ private fun handleMessage(
 
             "gameComplete" -> {
                 viewModel.clearEEFRTData(context)
+                exitRequested.value = true
                 dismiss(onBack)
             }
 
@@ -253,8 +337,4 @@ private fun handleMessage(
 
 private fun dismiss(onBack: () -> Unit) {
     Handler(Looper.getMainLooper()).post { onBack() }
-}
-
-private fun showDialogMessage(eefrtViewModel: EefrtScreenViewModel) {
-    eefrtViewModel.showExitDialog.value = true
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/CloseMessage.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/CloseMessage.kt
@@ -1,0 +1,10 @@
+package ai.a2i2.conductor.effrtdemoandroid.ui.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CloseMessage(
+    val shouldShowExitDialog: Boolean,
+    val incrementAttemptCount: Boolean,
+    val taskRequiresRestart: Boolean,
+)

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -99,6 +99,7 @@ class EefrtScreenViewModel(
     // we don't care for the business logic in this app, remember to add it into the main vibe up 2 apps
     fun clearEEFRTData(context: Context) {
         GameStorage(context).cachedGameState = null
+        resumeTrialAvailable.value = false
     }
 
     fun markCalibrationAsComplete(context: Context) {

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -28,7 +28,7 @@ class EefrtScreenViewModel(
     init {
         refreshData()
         val currentGameState = GameStorage(context).cachedGameState
-        resumeTrialAvailable = mutableStateOf((currentGameState?.trialNumber ?: 0) > 0)
+        resumeTrialAvailable = mutableStateOf(currentGameState?.isResumeTrialAvailable() ?: false)
     }
 
     private fun refreshData() {
@@ -85,7 +85,7 @@ class EefrtScreenViewModel(
 
     fun setCurrentGameState(context: Context, newGameState: GameCache?) {
         GameStorage(context).cachedGameState = newGameState
-        resumeTrialAvailable.value = (newGameState?.trialNumber ?: 0) > 0
+        resumeTrialAvailable.value = newGameState?.isResumeTrialAvailable() ?: false
     }
 
     fun getCurrentGameState(context: Context): GameCache? {

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -5,8 +5,10 @@ import ai.a2i2.conductor.effrtdemoandroid.persistence.GameCache
 import ai.a2i2.conductor.effrtdemoandroid.persistence.GameStorage
 import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
+import ai.a2i2.conductor.effrtdemoandroid.ui.EefrtScreen
 import ai.a2i2.conductor.effrtdemoandroid.util.GameConfigUtils
 import android.content.Context
+import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
@@ -14,6 +16,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
+import java.time.Instant
 
 class EefrtScreenViewModel(
     private val appDatabase: AppDatabase,
@@ -22,8 +25,11 @@ class EefrtScreenViewModel(
 
     private val _practiceTrialData = mutableStateOf<List<PracticeTaskAttempt>>(emptyList())
     private val _actualTrialData = mutableStateOf<List<TaskAttempt>>(emptyList())
+
     val resumeTrialAvailable: MutableState<Boolean>
     var showExitDialog: MutableState<Boolean> = mutableStateOf(false)
+    var interruptionTimestamp = mutableStateOf<Long?>(null)
+    var closeMessage = mutableStateOf<CloseMessage?>(null)
 
     init {
         refreshData()
@@ -108,5 +114,37 @@ class EefrtScreenViewModel(
 
     fun setCalibratedMaxPressCount(context: Context, pressCount: Int) {
         GameStorage(context).calibratedMaxPressCount = pressCount
+    }
+
+    fun showCloseDialog(closeMessage: CloseMessage) {
+        this.closeMessage.value = closeMessage
+        showExitDialog.value = true
+    }
+
+    fun dismissCloseDialog() {
+        closeMessage.value = null
+        showExitDialog.value = false
+    }
+
+    fun onConfirmCloseDialog(loggingTag: String) {
+        // No business logic for this app but a placeholder for the main apps
+        closeMessage.value?.let {
+            if (it.incrementAttemptCount) {
+                Log.d(
+                    loggingTag,
+                    "Incremented attempt count"
+                )
+            }
+
+            if (it.taskRequiresRestart) {
+                Log.d(
+                    loggingTag,
+                    "Task will be restarted on next load"
+                )
+            }
+        }
+
+        // dismiss the dialog
+        dismissCloseDialog()
     }
 }

--- a/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
@@ -23,7 +23,7 @@ struct ContentView: View {
                     Button("Cancel", role: .cancel) {}
                 }
 
-                if viewModel.gameCache?.isResumeTrialAvailable() ?? false, let cache = viewModel.gameCache {
+                if let cache = viewModel.gameCache, cache.isResumeTrialAvailable()  {
                     NavigationLink(destination: EEFRTView(gameCache: cache)
                         .ignoresSafeArea()
                         .navigationBarBackButtonHidden()) {

--- a/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/ContentView.swift
@@ -23,7 +23,7 @@ struct ContentView: View {
                     Button("Cancel", role: .cancel) {}
                 }
 
-                if viewModel.gameCache?.trialNumber ?? 0 > 0, let cache = viewModel.gameCache {
+                if viewModel.gameCache?.isResumeTrialAvailable() ?? false, let cache = viewModel.gameCache {
                     NavigationLink(destination: EEFRTView(gameCache: cache)
                         .ignoresSafeArea()
                         .navigationBarBackButtonHidden()) {

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -89,6 +89,7 @@ class EEFRTViewController: UIViewController {
 
         NotificationCenter.default.addObserver(self, selector: #selector(appWasBackgrounded), name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(appWillbeForegrounded), name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillBeTerminated), name: UIApplication.willTerminateNotification, object: nil)
     }
 
     deinit {
@@ -340,6 +341,13 @@ extension EEFRTViewController: WKScriptMessageHandler {
             webView.evaluateJavaScript("window.setupGameWithCache(\(stringifiedCache));")
             self.interruptionTimeout = nil // we can safely remove it from here
         }
+    }
+
+    func appWillBeTerminated() {
+        // if the app is terminated while the task is active, increment the attempt count,
+        // reset task progress or submit the task as complete if not the first attempt,
+        os_log(.debug, "Incremented attempt count")
+        os_log(.debug, "Task will be restarted on next load")
     }
 }
 

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -84,11 +84,15 @@ class EEFRTViewController: UIViewController {
         self.publicPath = publicPath
         self.indexFileUrl = indexFileURL
         super.init(nibName: nil, bundle: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(appWasBackgrounded), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillbeForegrounded), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
 
     deinit {
         NotificationCenter.default.removeObserver(self)
         webView.configuration.userContentController.removeAllScriptMessageHandlers()
+        webView.configuration.userContentController.removeAllUserScripts()
     }
 
     @available(*, unavailable)
@@ -166,7 +170,7 @@ class EEFRTViewController: UIViewController {
         webView.loadFileURL(indexFileUrl, allowingReadAccessTo: URL(fileURLWithPath: publicPath))
     }
 
-    private func showDismissDialog() {
+    private func showDismissDialog(closeMessage: CloseMessage) {
         let message = GameConfigUtils.rewardThresholdReached()
             ? "You'll still receive a bonus but won't be able to return to the task and add to your bonus payment."
             : "You have not completed enough rounds to earn the bonus payment and will lose your progress."
@@ -188,6 +192,16 @@ class EEFRTViewController: UIViewController {
                 style: .default
             ) { [weak self] _ in
                 guard let self else { return }
+                if closeMessage.incrementAttemptCount {
+                    // increment attempt count in the main app
+                    os_log(.debug, "Incremented attempt count")
+                }
+
+                if closeMessage.taskRequiresRestart {
+                    // the task needs to be restarted
+                    os_log(.debug, "Task will be restarted on next load")
+                }
+
                 delegate?.eefrtViewControllerDidRequestClose(self)
             }
         )
@@ -208,19 +222,40 @@ extension EEFRTViewController: WKScriptMessageHandler {
                 If they are still in the practice trials, just exit the task.
                 We also want to not show the exit dialog if they are shown the Times Up message.
 
-                Messages from this key will contain an Boolean value which determines if we show the exit dialog or not
+                We may also be requested to exit the task if a significant interruption has occured and will need to determine if the
+                task attempt count should be incremented or not as well.
              */
-            guard let shouldShowExitDialogFromJs = message.body as? String,
-                  let shouldShowExitDialog = Bool(shouldShowExitDialogFromJs) else {
+            guard let stringifiedDataFromJS = (message.body as? String)?.data(using: .utf8) else {
                 delegate?.eefrtViewControllerDidRequestClose(self)
                 return
             }
+            do {
+                // decode the message from the JS side
+                let decoder = JSONDecoder()
+                let decodedCloseMessageString = try decoder.decode(String.self, from: stringifiedDataFromJS)
+                let closeMessage = try decoder.decode(CloseMessage.self, from: Data(decodedCloseMessageString.utf8))
 
-            if shouldShowExitDialog {
-                showDismissDialog()
-            } else {
-                delegate?.eefrtViewControllerDidRequestClose(self)
+                // ensure its only incremented if the game is closed, the user has the option to cancel closing the task via the dialog
+                if !closeMessage.shouldShowExitDialog, closeMessage.incrementAttemptCount {
+                    // increment attempt count - in main app
+                    os_log(.debug, "Incremented attempt count")
+                }
+
+                // ensure the game data is reset if we've actually closed the task, similar scenario to the shouldShowExitDialog
+                if !closeMessage.shouldShowExitDialog, closeMessage.taskRequiresRestart {
+                    // the task needs to be restarted
+                    os_log(.debug, "Task will be restarted on next load")
+                }
+
+                if closeMessage.shouldShowExitDialog {
+                    showDismissDialog(closeMessage: closeMessage)
+                }
+            } catch let (error) {
+                os_log(.debug, "Unable to decode close message from JS side with error: \(error.localizedDescription)")
             }
+
+            // fallback for if we are unable to decode message or there was no message, just close the view
+            delegate?.eefrtViewControllerDidRequestClose(self)
 
         case Self.practiceTrialResultMessageKey:
             guard let stringifiedData = (message.body as? String)?.data(using: .utf8) else { return }
@@ -282,6 +317,23 @@ extension EEFRTViewController: WKScriptMessageHandler {
         default:
             os_log(.error, "Message type %s not implemented yet!", message.name)
         }
+    }
+}
+
+@objc private extension EEFRTViewController {
+    func appWasBackgrounded() {
+        // update the cache with the time the app was backgrounded
+        guard var cache = Defaults.gameCache else { return }
+        cache.interruptionTimestamp = Int64(Date().timeIntervalSince1970 * 1000) // convert seconds to milliseconds
+        Defaults.gameCache = cache
+    }
+
+    func appWillbeForegrounded() {
+        guard let cache = Defaults.gameCache,
+              let stringifiedCache = try? cache.stringify() else { return }
+
+        webView.evaluateJavaScript("window.setupGameWithCache(\(stringifiedCache));")
+        Defaults.gameCache?.interruptionTimestamp = nil // we can safely remove it from here
     }
 }
 

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -72,6 +72,8 @@ class EEFRTViewController: UIViewController {
     private let publicPath: String
     private let indexFileUrl: URL
 
+    private var interruptionTimeout: Int64?
+
     init(gameCache: GameCache?) {
         guard let publicPath = Bundle.main.path(forResource: "assets", ofType: nil) else {
             fatalError("Unable to locate 'assets' folder in main bundle")
@@ -250,7 +252,7 @@ extension EEFRTViewController: WKScriptMessageHandler {
                 if closeMessage.shouldShowExitDialog {
                     showDismissDialog(closeMessage: closeMessage)
                 }
-            } catch let (error) {
+            } catch {
                 os_log(.debug, "Unable to decode close message from JS side with error: \(error.localizedDescription)")
             }
 
@@ -322,18 +324,22 @@ extension EEFRTViewController: WKScriptMessageHandler {
 
 @objc private extension EEFRTViewController {
     func appWasBackgrounded() {
-        // update the cache with the time the app was backgrounded
-        guard var cache = Defaults.gameCache else { return }
-        cache.interruptionTimestamp = Int64(Date().timeIntervalSince1970 * 1000) // convert seconds to milliseconds
-        Defaults.gameCache = cache
+        // update the interruptionTimeout with the time the app was backgrounded
+        interruptionTimeout = Int64(Date().timeIntervalSince1970 * 1000) // convert seconds to milliseconds
     }
 
     func appWillbeForegrounded() {
-        guard let cache = Defaults.gameCache,
-              let stringifiedCache = try? cache.stringify() else { return }
+        guard var cache = Defaults.gameCache,
+              let interruptionTimeout else {
+            self.interruptionTimeout = nil // reset this value then return
+            return
+        }
+        cache.interruptionTimestamp = interruptionTimeout
 
-        webView.evaluateJavaScript("window.setupGameWithCache(\(stringifiedCache));")
-        Defaults.gameCache?.interruptionTimestamp = nil // we can safely remove it from here
+        if let stringifiedCache = try? cache.stringify() {
+            webView.evaluateJavaScript("window.setupGameWithCache(\(stringifiedCache));")
+            self.interruptionTimeout = nil // we can safely remove it from here
+        }
     }
 }
 

--- a/EEFRT Demo iOS/EEFRT Demo/Models/CloseMessage.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/CloseMessage.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct CloseMessage: Codable {
+    let shouldShowExitDialog: Bool
+    let incrementAttemptCount: Bool
+    let taskRequiresRestart: Bool
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // swift sometimes struggles decoding boolean values from the JS side so provide fallback to decode the string value instead
+        if let decodedBoolValue = try? container.decode(Bool.self, forKey: .shouldShowExitDialog) {
+            self.shouldShowExitDialog = decodedBoolValue
+        } else if let decodedStringValue = try? container.decode(String.self, forKey: .shouldShowExitDialog) {
+            self.shouldShowExitDialog = decodedStringValue.lowercased() == "true"
+        } else {
+            throw DecodingError.valueNotFound(Bool.self, .init(codingPath: [CodingKeys.shouldShowExitDialog], debugDescription: "Required field 'shouldShowExitDialog' not found"))
+        }
+
+        if let decodedBoolValue = try? container.decode(Bool.self, forKey: .incrementAttemptCount) {
+            self.incrementAttemptCount = decodedBoolValue
+        } else if let decodedStringValue = try? container.decode(String.self, forKey: .incrementAttemptCount) {
+            self.incrementAttemptCount = decodedStringValue.lowercased() == "true"
+        } else {
+            throw DecodingError.valueNotFound(Bool.self, .init(codingPath: [CodingKeys.incrementAttemptCount], debugDescription: "Required field 'incrementAttemptCount' not found"))
+        }
+
+        if let decodedBoolValue = try? container.decode(Bool.self, forKey: .taskRequiresRestart) {
+            self.taskRequiresRestart = decodedBoolValue
+        } else if let decodedStringValue = try? container.decode(String.self, forKey: .taskRequiresRestart) {
+            self.taskRequiresRestart = decodedStringValue.lowercased() == "true"
+        } else {
+            throw DecodingError.valueNotFound(Bool.self, .init(codingPath: [CodingKeys.taskRequiresRestart], debugDescription: "Required field 'taskRequiresRestart' not found"))
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case shouldShowExitDialog
+        case incrementAttemptCount
+        case taskRequiresRestart
+    }
+}

--- a/EEFRT Demo iOS/EEFRT Demo/Models/CloseMessage.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/CloseMessage.swift
@@ -8,30 +8,27 @@ struct CloseMessage: Codable {
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        // swift sometimes struggles decoding boolean values from the JS side so provide fallback to decode the string value instead
-        if let decodedBoolValue = try? container.decode(Bool.self, forKey: .shouldShowExitDialog) {
-            self.shouldShowExitDialog = decodedBoolValue
-        } else if let decodedStringValue = try? container.decode(String.self, forKey: .shouldShowExitDialog) {
-            self.shouldShowExitDialog = decodedStringValue.lowercased() == "true"
-        } else {
-            throw DecodingError.valueNotFound(Bool.self, .init(codingPath: [CodingKeys.shouldShowExitDialog], debugDescription: "Required field 'shouldShowExitDialog' not found"))
-        }
+        self.shouldShowExitDialog = try CloseMessage.decodeBoolOrString(forKey: .shouldShowExitDialog, from: container)
+        self.incrementAttemptCount = try CloseMessage.decodeBoolOrString(forKey: .incrementAttemptCount, from: container)
+        self.taskRequiresRestart = try CloseMessage.decodeBoolOrString(forKey: .taskRequiresRestart, from: container)
+    }
 
-        if let decodedBoolValue = try? container.decode(Bool.self, forKey: .incrementAttemptCount) {
-            self.incrementAttemptCount = decodedBoolValue
-        } else if let decodedStringValue = try? container.decode(String.self, forKey: .incrementAttemptCount) {
-            self.incrementAttemptCount = decodedStringValue.lowercased() == "true"
-        } else {
-            throw DecodingError.valueNotFound(Bool.self, .init(codingPath: [CodingKeys.incrementAttemptCount], debugDescription: "Required field 'incrementAttemptCount' not found"))
+    /// Attempts to decode a boolean value for the given key, falling back to decoding a string (e.g., "true"/"false") if needed.
+    /// This is necessary because sometimes values sent from the JS side are encoded as strings instead of booleans.
+    private static func decodeBoolOrString(forKey key: CodingKeys, from container: KeyedDecodingContainer<CodingKeys>) throws -> Bool {
+        if let boolValue = try? container.decode(Bool.self, forKey: key) {
+            return boolValue
         }
-
-        if let decodedBoolValue = try? container.decode(Bool.self, forKey: .taskRequiresRestart) {
-            self.taskRequiresRestart = decodedBoolValue
-        } else if let decodedStringValue = try? container.decode(String.self, forKey: .taskRequiresRestart) {
-            self.taskRequiresRestart = decodedStringValue.lowercased() == "true"
-        } else {
-            throw DecodingError.valueNotFound(Bool.self, .init(codingPath: [CodingKeys.taskRequiresRestart], debugDescription: "Required field 'taskRequiresRestart' not found"))
+        if let stringValue = try? container.decode(String.self, forKey: key) {
+            return stringValue.lowercased() == "true"
         }
+        throw DecodingError.valueNotFound(
+            Bool.self,
+            .init(
+                codingPath: [key],
+                debugDescription: "Required field '\(key.stringValue)' not found or not convertible to Bool"
+            )
+        )
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
@@ -79,4 +79,8 @@ struct GameCache: Codable, DefaultsSerializable {
         let data = try encoder.encode(self)
         return String(decoding: data, as: UTF8.self)
     }
+    
+    func isResumeTrialAvailable() -> Bool {
+        practiceComplete || trialNumber > 0
+    }
 }

--- a/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
@@ -10,6 +10,7 @@ struct GameCache: Codable, DefaultsSerializable {
     var randTrialsIdx: [Int]?
     var trialSeqFilename: String?
     var calibrationComplete: Bool
+    var interruptionTimestamp: Int64?
 
     // Default initializer with default values
     init(
@@ -20,7 +21,8 @@ struct GameCache: Codable, DefaultsSerializable {
         trialResults: [String: Int] = [:],
         randTrialsIdx: [Int]? = nil,
         trialSeqFilename: String? = nil,
-        calibrationComplete: Bool = false
+        calibrationComplete: Bool = false,
+        interuptionTimestamp: Int64? = nil
     ) {
         self.practiceComplete = practiceComplete
         self.trialNumber = trialNumber
@@ -30,6 +32,7 @@ struct GameCache: Codable, DefaultsSerializable {
         self.randTrialsIdx = randTrialsIdx
         self.trialSeqFilename = trialSeqFilename
         self.calibrationComplete = calibrationComplete
+        self.interruptionTimestamp = interuptionTimestamp
     }
 
     // Decoder initializer
@@ -43,6 +46,7 @@ struct GameCache: Codable, DefaultsSerializable {
         self.randTrialsIdx = try container.decodeIfPresent([Int].self, forKey: .randTrialsIdx)
         self.trialSeqFilename = try container.decodeIfPresent(String.self, forKey: .trialSeqFilename)
         self.calibrationComplete = try container.decode(Bool.self, forKey: .calibrationComplete)
+        self.interruptionTimestamp = try container.decodeIfPresent(Int64.self, forKey: .interruptionTimestamp)
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -55,6 +59,7 @@ struct GameCache: Codable, DefaultsSerializable {
         try container.encodeIfPresent(randTrialsIdx, forKey: .randTrialsIdx)
         try container.encodeIfPresent(trialSeqFilename, forKey: .trialSeqFilename)
         try container.encodeIfPresent(calibrationComplete, forKey: .calibrationComplete)
+        try container.encodeIfPresent(interruptionTimestamp, forKey: .interruptionTimestamp)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -66,6 +71,7 @@ struct GameCache: Codable, DefaultsSerializable {
         case randTrialsIdx
         case trialSeqFilename
         case calibrationComplete
+        case interruptionTimestamp
     }
 
     func stringify() throws -> String {

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Note: When 'Game Time' is mentioned it refers to the Clock used by the Phaser Ga
 | `trialReward2` | Number | The reward in coins for the second choice for the current trial. |
 | `trialEffort2` | Number | The number of taps required to reach the effort threshold for the second choice in the current trial. |
 | `trialEffortPropMax2` | Float | A percentage value of the number of taps required to reach the effort threshold for the second choice in the current trial vs the `thresholdMax` determined from the calibration trials. |
-| `choice` | String | The user's choice of which reward they want ('route 1', 'route 2' or 'timeout'). 'Timeout' means they failed to select a route within the time given. |
-| `choiceRT` | Float | The time in milliseconds it took for the user to make their choice after being shown the RouteSelectorPanel. |
+| `choice` | String | The user's choice of which reward they want ('route 1', 'route 2', 'timeout' or 'interruption'). 'Timeout' means they failed to select a route within the time given. 'Interruption' means that the app was backgrounded and foregrounded whilst the task was running. |
+| `choiceRT` | Float | The time in milliseconds it took for the user to make their choice after being shown the RouteSelectorPanel. If this value is `0` it means an interruptuion occured and the trial was skipped. |
 | `pressCount` | Number | The number of times the user pressed the power button during the power up animation. |
 | `pressTimes` | Array[Number] | An array containing each time the power button was pressed curing the power up animation. Individual press counts are derived from the current Game Time at which the tap occured. |
 | `trialSuccess` | Boolean | Whether or not the user reached the effort threshold current trial (0 or 1). |
@@ -97,4 +97,4 @@ Note: When 'Game Time' is mentioned it refers to the Clock used by the Phaser Ga
 | `recalibration` | Boolean | Whether or not the `thresholdMax` was adjusted due to the user reaching a new maximum tap rate. |
 | `thresholdMax` | Number | A theoretical maximum number of taps the user can achieve in the availiable `eefrtTimeLimit` based on their maximum number of taps per second. This represents 100% of the participant's effort and trial effort thresholds are calculated based of this value. |
 | `createdAt` | Date | A timestamp measured in seconds since January 1, 1970 (UTC). |
-| `powerCountdown` | Number | The Game Time at which the power-up countdown timer begins to tick down. |
+| `powerCountdown` | Number | The Game Time at which the power-up countdown timer begins to tick down. If this value is `0` then an interruption occured and the powertimer was never shown. |

--- a/public/src/elements/BottomScreenPanel.js
+++ b/public/src/elements/BottomScreenPanel.js
@@ -2,12 +2,16 @@ import CountdownPanel from "./CountdownPanel.js";
 import eventsCenter from "../eventsCenter.js";
 
 export const TIMER_EXPIRED_KEY = 'bottomPanelTimerExpired';
+export const BREAK_TAG = 'bottomScreenBreak';
+export const TIMEOUT_TAG = 'bottomScreenTimeout';
+export const ARE_YOU_THERE_TAG = 'bottomScreenAreYouThere';
 
 export default class BottomScreenPanel {
-    constructor(scene, x, titleString, subtitleString, bottomButtonString, breakTimeMS, onContinuePressed = () => {}, onTimeout = () => {}) {
+    constructor(scene, x, titleString, subtitleString, bottomButtonString, breakTimeMS, tag, onContinuePressed = () => {}, onTimeout = () => {}) {
         this.scene = scene;
         this.breakTimeMS = breakTimeMS;
         this.onTimeout = onTimeout;
+        this.tag = tag;
 
         let y = 0; // This coordinate will be calculated after the panel height is calculated
         let width = window.innerWidth;

--- a/public/src/elements/BottomScreenPanel.js
+++ b/public/src/elements/BottomScreenPanel.js
@@ -5,6 +5,8 @@ export const TIMER_EXPIRED_KEY = 'bottomPanelTimerExpired';
 export const BREAK_TAG = 'bottomScreenBreak';
 export const TIMEOUT_TAG = 'bottomScreenTimeout';
 export const ARE_YOU_THERE_TAG = 'bottomScreenAreYouThere';
+export const EXIT_TASK_TAG = 'bottomScreenExitTask';
+export const GAME_COMPLETE_TAG = 'bottomScreenGameComplete';
 
 export default class BottomScreenPanel {
     constructor(scene, x, titleString, subtitleString, bottomButtonString, breakTimeMS, tag, onContinuePressed = () => {}, onTimeout = () => {}) {

--- a/public/src/embedContext/CloseMessage.js
+++ b/public/src/embedContext/CloseMessage.js
@@ -1,0 +1,11 @@
+export default class CloseMessage {
+    constructor(shouldShowExitDialog, incrementAttemptCount, taskRequiresRestart) {
+        this.shouldShowExitDialog = shouldShowExitDialog;
+        this.incrementAttemptCount = incrementAttemptCount;
+        this.taskRequiresRestart = taskRequiresRestart;
+    }
+
+    stringify() {
+        return JSON.stringify(this);
+    }
+}

--- a/public/src/embedContext/GameCache.js
+++ b/public/src/embedContext/GameCache.js
@@ -1,7 +1,7 @@
 export default class GameCache {
     static cache = null;
 
-    constructor(practiceComplete, trialNumber, maxPressCount, coinRunningTotal, trialResults, randTrialsIdx, trialSeqFilename, calibrationComplete) {
+    constructor(practiceComplete, trialNumber, maxPressCount, coinRunningTotal, trialResults, randTrialsIdx, trialSeqFilename, calibrationComplete, interruptionTimestamp) {
         this.practiceComplete = practiceComplete;
         this.trialNumber = trialNumber;
         this.maxPressCount = maxPressCount;
@@ -10,6 +10,7 @@ export default class GameCache {
         this.randTrialsIdx = randTrialsIdx;
         this.trialSeqFilename = trialSeqFilename;
         this.calibrationComplete = calibrationComplete;
+        this.interruptionTimestamp = interruptionTimestamp;
     }
 
     stringify() {

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -124,7 +124,6 @@ export default class InteruptionsHandler {
 
             // 3F
             if (!context.bottomScreenPanel && interuptionLengthMs < threeMinsMs) {
-                console.log('3F');
                 context.continueAfterInterruption();
                 return;
             }

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -19,8 +19,8 @@ export default class InteruptionsHandler {
         // scenario 1 - interupted during practice rounds before main trials - restart from practice with no increment to attempt count
         if (cache.practiceComplete == false && cache.trialNumber == 0) {
             console.log('1A');
-            let closeMessage = new CloseMessage(false, false, false);
-            EmbedContext.sendMessage('close', closeMessage.stringify());
+            // show exit task dialog to let the user know they need to exit and return to the task from the beginning of the practice rounds
+            context.interruptionExitTaskDialog = true;
             return;
         }
 

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -129,7 +129,7 @@ export default class InteruptionsHandler {
                 return; // let the user continue without incrementing the attempt count, the task is considered done at this point.
             } else { // 4B
                 console.log('4B');
-                EmbedContext.sendMessage('gameComplete');
+                EmbedContext.sendMessage('gameComplete', {});
                 return; // game is complete, exit immediately
             }
         }

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -5,7 +5,6 @@ import CloseMessage from "./CloseMessage";
 
 export default class InteruptionsHandler {
     static handleInteruption(context, cache) {
-        console.log('cache: ' + cache);
         if (cache == null || !cache.interruptionTimestamp) {
             return;
         }
@@ -21,6 +20,7 @@ export default class InteruptionsHandler {
 
         // scenario 1 - interupted during practice rounds before main trials - restart from practice with no increment to attempt count
         if (cache.practiceComplete == false && cache.trialNumber == 0) {
+            console.log('1A');
             let closeMessage = new CloseMessage(false, false, false);
             EmbedContext.sendMessage('close', closeMessage.stringify());
             return;
@@ -97,11 +97,12 @@ export default class InteruptionsHandler {
             // 3D
             if (!context.bottomScreenPanel && interuptionLengthMs >= threeMinsMs && interuptionLengthMs < fiveMinsMs) {
                 let numAreYouThereDialogsShown = context.missedTrialDialogsShown ?? 0;
-                console.log('3D');
                 // if havent been shown the are you still there dialog, show it
                 if (numAreYouThereDialogsShown < missedTrialDialogLimit) {
+                    console.log('3D-A');
                     context.interruptionShowAreYouThereDialog = true;
                 } else {
+                    console.log('3D-B');
                     // we've been shown the are you still there dialog too many times, show the times up dialog instead
                     context.interruptionShowTimesUpDialog = true;
                 }

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -1,0 +1,140 @@
+import GameCache from "./GameCache";
+import { ARE_YOU_THERE_TAG, TIMEOUT_TAG } from "../elements/BottomScreenPanel";
+import { taskRewardsPayoutThreshold, missedTrialDialogLimit } from "../versionInfo";
+import CloseMessage from "./CloseMessage";
+
+export default class InteruptionsHandler {
+    static handleInteruption(context, cache) {
+        console.log('cache: ' + cache);
+        if (cache == null || !cache.interruptionTimestamp) {
+            return;
+        }
+
+        const twoMinsMs = 1000 * 60 * 2;
+        const threeMinsMs = 1000 * 60 * 3;
+        const fourMinsMs = 1000 * 60 * 4;
+        const fiveMinsMs = 1000 * 60 * 5;
+        const nTrials = 44;
+        let interuptionLengthMs = Date.now() - cache.interruptionTimestamp;
+        console.log('Interuption Seconds: ' + interuptionLengthMs / 1000);
+        let completionThresholdTrialNo = Math.floor(taskRewardsPayoutThreshold * nTrials);
+
+        // scenario 1 - interupted during practice rounds before main trials - restart from practice with no increment to attempt count
+        if (cache.practiceComplete == false && cache.trialNumber == 0) {
+            let closeMessage = new CloseMessage(false, false, false);
+            EmbedContext.sendMessage('close', closeMessage.stringify());
+            return;
+        }
+
+        // scenario 2 - interupted after practice but before the 2 calibration trials are complete:
+        /*
+            2A: Away for over 3 mins - task ends but allowed to return (infinately?)
+            2B: Away for less than 3 mins - task still active, let them continue
+        */
+        if (cache.practiceComplete == true && cache.trialNumber <= 1) {
+            // 2A
+            if (interuptionLengthMs > threeMinsMs) {
+                // dont increment attempt count? Exit the task and let them return
+                console.log('2A');
+                let closeMessage = new CloseMessage(false, false, false);
+                EmbedContext.sendMessage('close', closeMessage.stringify());
+                return;
+            } else { // 2B
+                console.log('2B');
+                return; // let the user continue from where they are, no increment to attempt count
+            }
+        }
+
+        // scenario 3 - interupted before reaching 80% threshold -
+        /*
+            3A: User returns while the are you still there dialog is active - let them continue only if they continue when the dialog would have been active.
+            3B: User returns while the time out dialog is active but the additional 2 min timer is active - close the task and let them resume from where they left off (if first attempt)
+            3C: User returns after the times out internal timer finishes (1 min for 3 timeouts, 2 mins for are you still there, 2 mins for times up dialog) - Restart the task from the beginning (if first attempt) or submit as complete if not first attempt
+            3D: User is gone for 3-5 mins and there is no active dialog - show the are you still there dialog (or the times up dialog if shown before)
+            3E: User is gone for over 5 mins and theres no active dialog - Show the Times up dialog and restart the task from the beginning (if first attempt) or submit as complete if not.
+        */
+        if (cache.trialNumber >= 2 && cache.trialNumber < completionThresholdTrialNo) {
+            // 3A
+            if (context.bottomScreenPanel && context.bottomScreenPanel.tag == ARE_YOU_THERE_TAG && interuptionLengthMs < twoMinsMs) {
+                // let the user continue from where they are as the dialog would have been still active, no increment to attempt count
+                // the timer will continue to tick down when they return so if they dont continue within the reminaing time they will get the times up dialog.
+                console.log('3A');
+                return;
+            } else if (context.bottomScreenPanel && context.bottomScreenPanel.tag == ARE_YOU_THERE_TAG && interuptionLengthMs >= twoMinsMs && interuptionLengthMs < fourMinsMs) {
+                // the user returned after the are you still there dialog would have timed out but before the time out dialogs 2 mins internal countdown has expired,
+                // increment attempt count but they can countinue from where they left off
+                console.log('3A');
+                let closeMessage = new CloseMessage(false, true, false);
+                EmbedContext.sendMessage('close', closeMessage.stringify());
+                return;
+            } else if (context.bottomScreenPanel && context.bottomScreenPanel.tag == ARE_YOU_THERE_TAG && interuptionLengthMs >= fourMinsMs) {
+                // the user returned after both the are you still there and times up times up dialogs would have timed out,
+                // increment attempt count and restart from the beginning
+                console.log('3A');
+                let closeMessage = new CloseMessage(false, true, true);
+                EmbedContext.sendMessage('close', closeMessage.stringify());
+                return;
+            }
+
+            // 3B
+            if (context.bottomScreenPanel && context.bottomScreenPanel.tag == TIMEOUT_TAG && interuptionLengthMs < twoMinsMs) {
+                // Increment attempt count. Exit the task and let them return where they left off if its their first attempt
+                console.log('3B');
+                let closeMessage = new CloseMessage(false, true, false);
+                EmbedContext.sendMessage('close', closeMessage.stringify());
+                return;
+            }
+
+            // 3C
+            if (context.bottomScreenPanel && context.bottomScreenPanel.tag == TIMEOUT_TAG && interuptionLengthMs >= twoMinsMs) {
+                // The times out dialog internal timer would have timed out, restart the task from the beginning
+                console.log('3C');
+                let closeMessage = new CloseMessage(false, true, true);
+                EmbedContext.sendMessage('close', closeMessage.stringify());
+                return;
+            }
+
+            // 3D
+            if (!context.bottomScreenPanel && interuptionLengthMs >= threeMinsMs && interuptionLengthMs < fiveMinsMs) {
+                let numAreYouThereDialogsShown = context.missedTrialDialogsShown ?? 0;
+                console.log('3D');
+                // if havent been shown the are you still there dialog, show it
+                if (numAreYouThereDialogsShown < missedTrialDialogLimit) {
+                    context.interruptionShowAreYouThereDialog = true;
+                } else {
+                    // we've been shown the are you still there dialog too many times, show the times up dialog instead
+                    context.interruptionShowTimesUpDialog = true;
+                }
+                return;
+            }
+
+            // 3E
+            if (!context.bottomScreenPanel && interuptionLengthMs >= fiveMinsMs) {
+                console.log('3E');
+                context.interruptionShowTimesUpDialog = true;
+                context.taskRequiresRestart = true;
+                return;
+            }
+        }
+
+        // scenario 4 - interupted after reaching 80% threshold -
+        /*
+            4A: User returns before 5 mins - Let them continue
+            4B: User returns after 5 mins - Mark the task as complete and exit - survey is availiable
+        */
+        if (cache.trialNumber >= completionThresholdTrialNo && cache.trialNumber <= nTrials) {
+            // 4A
+            if (interuptionLengthMs < fiveMinsMs) {
+                console.log('4A');
+                return; // let the user continue without incrementing the attempt count, the task is considered done at this point.
+            } else { // 4B
+                console.log('4B');
+                EmbedContext.sendMessage('gameComplete');
+                return; // game is complete, exit immediately
+            }
+        }
+
+        // Scenario 5 - interupted after the main trials are completed but before answering the feedback question - Show the feedback screens once only.
+        // Handled in native apps
+    }
+}

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -41,6 +41,7 @@ export default class InteruptionsHandler {
                 return;
             } else { // 2B
                 console.log('2B');
+                context.continueAfterInterruption();
                 return; // let the user continue from where they are, no increment to attempt count
             }
         }
@@ -52,6 +53,7 @@ export default class InteruptionsHandler {
             3C: User returns after the times out internal timer finishes (1 min for 3 timeouts, 2 mins for are you still there, 2 mins for times up dialog) - Restart the task from the beginning (if first attempt) or submit as complete if not first attempt
             3D: User is gone for 3-5 mins and there is no active dialog - show the are you still there dialog (or the times up dialog if shown before)
             3E: User is gone for over 5 mins and theres no active dialog - Show the Times up dialog and restart the task from the beginning (if first attempt) or submit as complete if not.
+            3F: User is gone for less than 3 mins and theres no active dialog - dont let the user interract with the current trial and skip ahead to the next trial.
         */
         if (cache.trialNumber >= 2 && cache.trialNumber < completionThresholdTrialNo) {
             // 3A
@@ -101,10 +103,12 @@ export default class InteruptionsHandler {
                 if (numAreYouThereDialogsShown < missedTrialDialogLimit) {
                     console.log('3D-A');
                     context.interruptionShowAreYouThereDialog = true;
+                    context.continueAfterInterruption();
                 } else {
                     console.log('3D-B');
                     // we've been shown the are you still there dialog too many times, show the times up dialog instead
                     context.interruptionShowTimesUpDialog = true;
+                    context.continueAfterInterruption();
                 }
                 return;
             }
@@ -114,6 +118,14 @@ export default class InteruptionsHandler {
                 console.log('3E');
                 context.interruptionShowTimesUpDialog = true;
                 context.taskRequiresRestart = true;
+                context.continueAfterInterruption();
+                return;
+            }
+
+            // 3F
+            if (!context.bottomScreenPanel && interuptionLengthMs < threeMinsMs) {
+                console.log('3F');
+                context.continueAfterInterruption();
                 return;
             }
         }
@@ -127,6 +139,7 @@ export default class InteruptionsHandler {
             // 4A
             if (interuptionLengthMs < fiveMinsMs) {
                 console.log('4A');
+                context.continueAfterInterruption();
                 return; // let the user continue without incrementing the attempt count, the task is considered done at this point.
             } else { // 4B
                 console.log('4B');

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -1,7 +1,5 @@
-import GameCache from "./GameCache";
 import { ARE_YOU_THERE_TAG, TIMEOUT_TAG } from "../elements/BottomScreenPanel";
 import { taskRewardsPayoutThreshold, missedTrialDialogLimit } from "../versionInfo";
-import CloseMessage from "./CloseMessage";
 
 export default class InteruptionsHandler {
     static handleInteruption(context, cache) {
@@ -34,10 +32,11 @@ export default class InteruptionsHandler {
         if (cache.practiceComplete == true && cache.trialNumber <= 1) {
             // 2A
             if (interuptionLengthMs > threeMinsMs) {
-                // dont increment attempt count? Exit the task and let them return
+                // show exit task dialog to let the user know they need to exit and return to the task from where they left off
                 console.log('2A');
-                let closeMessage = new CloseMessage(false, false, false);
-                EmbedContext.sendMessage('close', closeMessage.stringify());
+                context.taskRequiresRestart = false;
+                context.interruptionExitTaskDialog = true;
+
                 return;
             } else { // 2B
                 console.log('2B');
@@ -64,35 +63,35 @@ export default class InteruptionsHandler {
                 return;
             } else if (context.bottomScreenPanel && context.bottomScreenPanel.tag == ARE_YOU_THERE_TAG && interuptionLengthMs >= twoMinsMs && interuptionLengthMs < fourMinsMs) {
                 // the user returned after the are you still there dialog would have timed out but before the time out dialogs 2 mins internal countdown has expired,
-                // increment attempt count but they can countinue from where they left off
+                // show the times up dialog andincrement attempt count. If they return before the 2 mins timeout occurs then they can countinue from where they left off
                 console.log('3A-B');
-                let closeMessage = new CloseMessage(false, true, false);
-                EmbedContext.sendMessage('close', closeMessage.stringify());
+                context.taskRequiresRestart = false;
+                context.switchToTimesUpDialog();
                 return;
             } else if (context.bottomScreenPanel && context.bottomScreenPanel.tag == ARE_YOU_THERE_TAG && interuptionLengthMs >= fourMinsMs) {
                 // the user returned after both the are you still there and times up times up dialogs would have timed out,
-                // increment attempt count and restart from the beginning
+                // show the times up dialog in its place and then increment attempt count and restart from the beginning
                 console.log('3A-C');
-                let closeMessage = new CloseMessage(false, true, true);
-                EmbedContext.sendMessage('close', closeMessage.stringify());
+                context.taskRequiresRestart = true;
+                context.switchToTimesUpDialog();
                 return;
             }
 
             // 3B
             if (context.bottomScreenPanel && context.bottomScreenPanel.tag == TIMEOUT_TAG && interuptionLengthMs < twoMinsMs) {
-                // Increment attempt count. Exit the task and let them return where they left off if its their first attempt
+                // Increment attempt count. Keep the times up dialog active and let them manually exit via the dialog, if they trigger
+                // the extra 2 min timeout then they will need to restart the task, otherwise let them continue from where they left off.
                 console.log('3B');
-                let closeMessage = new CloseMessage(false, true, false);
-                EmbedContext.sendMessage('close', closeMessage.stringify());
+                context.taskRequiresRestart = false;
                 return;
             }
 
             // 3C
             if (context.bottomScreenPanel && context.bottomScreenPanel.tag == TIMEOUT_TAG && interuptionLengthMs >= twoMinsMs) {
-                // The times out dialog internal timer would have timed out, restart the task from the beginning
+                // The times out dialog internal timer would have timed out,
+                // let the user manually exit via the dialog and restart the task from the beginning
                 console.log('3C');
-                let closeMessage = new CloseMessage(false, true, true);
-                EmbedContext.sendMessage('close', closeMessage.stringify());
+                context.taskRequiresRestart = true;
                 return;
             }
 
@@ -140,10 +139,14 @@ export default class InteruptionsHandler {
                 console.log('4A');
                 context.continueAfterInterruption();
                 return; // let the user continue without incrementing the attempt count, the task is considered done at this point.
-            } else { // 4B
+            } else {
+                // 4B
+                // Note: While this scenario covers 4B there might be overlaps between this and scenario 3F-A -> 3F-D given the animations are allowed to continue
+                // so here might be a double up in the logs here. Once they reach the end of the bridge the completion dialog is then shown and they can exit the game from there.
                 console.log('4B');
-                EmbedContext.sendMessage('gameComplete', {});
-                return; // game is complete, exit immediately
+                context.interruptionGameCompleteDialog = true;
+                context.continueAfterInterruption();
+                return;
             }
         }
 

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -58,19 +58,19 @@ export default class InteruptionsHandler {
             if (context.bottomScreenPanel && context.bottomScreenPanel.tag == ARE_YOU_THERE_TAG && interuptionLengthMs < twoMinsMs) {
                 // let the user continue from where they are as the dialog would have been still active, no increment to attempt count
                 // the timer will continue to tick down when they return so if they dont continue within the reminaing time they will get the times up dialog.
-                console.log('3A');
+                console.log('3A-A');
                 return;
             } else if (context.bottomScreenPanel && context.bottomScreenPanel.tag == ARE_YOU_THERE_TAG && interuptionLengthMs >= twoMinsMs && interuptionLengthMs < fourMinsMs) {
                 // the user returned after the are you still there dialog would have timed out but before the time out dialogs 2 mins internal countdown has expired,
                 // increment attempt count but they can countinue from where they left off
-                console.log('3A');
+                console.log('3A-B');
                 let closeMessage = new CloseMessage(false, true, false);
                 EmbedContext.sendMessage('close', closeMessage.stringify());
                 return;
             } else if (context.bottomScreenPanel && context.bottomScreenPanel.tag == ARE_YOU_THERE_TAG && interuptionLengthMs >= fourMinsMs) {
                 // the user returned after both the are you still there and times up times up dialogs would have timed out,
                 // increment attempt count and restart from the beginning
-                console.log('3A');
+                console.log('3A-C');
                 let closeMessage = new CloseMessage(false, true, true);
                 EmbedContext.sendMessage('close', closeMessage.stringify());
                 return;

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -18,9 +18,8 @@ export default class InteruptionsHandler {
 
         // scenario 1 - interupted during practice rounds before main trials - restart from practice with no increment to attempt count
         if (cache.practiceComplete == false && cache.trialNumber == 0) {
-            console.log('1A');
-            // show exit task dialog to let the user know they need to exit and return to the task from the beginning of the practice rounds
-            context.interruptionExitTaskDialog = true;
+            // show the exit dialog immedately after an interruption
+            context.showExitDialogAfterInterruption();
             return;
         }
 

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -407,10 +407,14 @@ export default class MainTask extends BaseScene {
         */
     
         if (this.player.sprite.x <= decisionPointX && this.player.sprite.anims.currentAnim.key == 'run') {
+            console.log('3F-A');
+
             // signal that the route selector panel shouldn't be shown
             this.interruptionOccured = true;
             return;
         } else if (this.routeSelectorPanel != null && this.player.sprite.body.velocity.x == 0 && this.player.sprite.anims.currentAnim.key == 'wait') {
+            console.log('3F-B');
+
             // ensure the choice is set in the registry
             this.registry.set('choice', 'interruption');
 
@@ -424,6 +428,8 @@ export default class MainTask extends BaseScene {
 
             return;
         } else if (this.powerPanel != null && this.player.sprite.anims.currentAnim.key == 'powerup') {
+            console.log('3F-C');
+
             // ensure the choice is set in the registry
             this.registry.set('choice', 'interruption');
 
@@ -435,6 +441,7 @@ export default class MainTask extends BaseScene {
             eventsCenter.emit(POWER_UP_COMPLETE_KEY);    
         } else {
             // do nothing, player will be walking across the bridge
+            console.log('3F-D');
         }
     }
 }

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -51,7 +51,6 @@ var trialEffort2;
 var trialEffortPropChosen
 var trialEffort;
 var nCoins = 0; 
-var feedbackMessage;
 var feedbackTime = 1000;
 var animationTime = 400;
 var blockNo = 0;
@@ -170,6 +169,8 @@ export default class MainTask extends BaseScene {
         this.interruptionShowAreYouThereDialog = false;
         this.interruptionShowTimesUpDialog = false;
         this.taskRequiresRestart = false;
+        this.interruptionOccured = false;
+        this.routeSelectorPanel = null;
 
         // setup the game with the cached game state if present
         loadGameFromCache(this);
@@ -393,6 +394,49 @@ export default class MainTask extends BaseScene {
             this.scene.stop();
         }
     }
+
+    continueAfterInterruption() {
+        // a user was interrupted whilst in the middle of an individual trial, in this scenario we won't allow them to
+        // interract with that individual trial and will instead start from the beginning of the next trial.
+    
+        /*
+            1. If current animation playing is the walking animation before the route selector apears - prevent the power panel from appearing but still show the interruption message
+            2. If the route selector panel is visible, close it, show the interruption message and walk across the bridge
+            3. If the power up scene is active, cancel it, show an interruption message and walk across the bridge
+            4. If the user has already completed the trial, do nothing, the player will be walking across the bridge anyway
+        */
+    
+        if (this.player.sprite.x <= decisionPointX && this.player.sprite.anims.currentAnim.key == 'run') {
+            // signal that the route selector panel shouldn't be shown
+            this.interruptionOccured = true;
+            return;
+        } else if (this.routeSelectorPanel != null && this.player.sprite.body.velocity.x == 0 && this.player.sprite.anims.currentAnim.key == 'wait') {
+            // ensure the choice is set in the registry
+            this.registry.set('choice', 'interruption');
+
+            // destroy the RouteSelectorPanel and proceed to the trial outcome
+            this.routeSelectorPanel.destroy();
+            this.routeSelectorPanel = null;
+
+            // manually trigger the power up complete event so we can skip the current trial
+            eventsCenter.once(POWER_UP_COMPLETE_KEY, effortOutcome, this);
+            eventsCenter.emit(POWER_UP_COMPLETE_KEY);
+
+            return;
+        } else if (this.powerPanel != null && this.player.sprite.anims.currentAnim.key == 'powerup') {
+            // ensure the choice is set in the registry
+            this.registry.set('choice', 'interruption');
+
+            this.powerPanel.destroy();
+            this.powerPanel = null;
+
+            // manually trigger the power up complete event so we can skip the current trial
+            // listen was already set up when the power panel was created
+            eventsCenter.emit(POWER_UP_COMPLETE_KEY);    
+        } else {
+            // do nothing, player will be walking across the bridge
+        }
+    }
 }
 
 ///////////////////////////////FUNCTIONS FOR CONTROLLING TRIAL SEQUENCE/////////////////////////////////////
@@ -409,10 +453,18 @@ var displayChoicePanel = function () {
     this.coins1 = new Coins(this, midbridgeX-(trialReward1*30)/2, 235 + smallDeviceOffset, trialReward1); // coins in sky
     this.coins2 = new Coins(this, midbridgeX-(trialReward2*30)/2, 360 + smallDeviceOffset, trialReward2); // coins on bridge
 
+    // if an interruption occured before we display the choice panel, 
+    if (this.interruptionOccured) {
+        this.registry.set('choice', 'interruption');
+        eventsCenter.once(POWER_UP_COMPLETE_KEY, effortOutcome, this);
+        eventsCenter.emit(POWER_UP_COMPLETE_KEY);
+        return;
+    }
+
     const camera = this.cameras.main;
     const centerX = camera.scrollX + camera.width / 2;
 
-    const panel = new RouteSelectorPanel(
+    this.routeSelectorPanel = new RouteSelectorPanel(
         this,
         centerX,
         trialReward1,
@@ -425,7 +477,7 @@ var displayChoicePanel = function () {
         },
         timeout
     );
-    this.add.existing(panel.container);
+    this.add.existing(this.routeSelectorPanel.container);
     
     // once choice is entered, get choice info and route to relevant next step
     eventsCenter.once('choiceComplete', doChoice, this);
@@ -448,15 +500,14 @@ var doChoice = function () {
         this.player.sprite.anims.play('powerup', true);
         // until time limit reached:
         eventsCenter.once(POWER_UP_COMPLETE_KEY, effortOutcome, this)
-        }
-    else if (choice == 'route 2') {  // if participant chooses the low effort option
+    } else if (choice == 'route 2') {  // if participant chooses the low effort option
         // timer panel pops up  
         this.powerPanel = new PowerPanel(this, centerX, effortTime, trialReward2, trialEffortPropMax2, trialEffort2);
         // and play player 'power-up' animation
         this.player.sprite.anims.play('powerup', true);
         // until time limit reached:
         eventsCenter.once(POWER_UP_COMPLETE_KEY, effortOutcome, this)
-    } else { // user failed to make a choice before timeout
+    } else if (choice == 'timeout') { // user failed to make a choice before timeout
         // No TimerPanel to emit the timesup event, so we emit it manually so the 'this' context can be passed through
         eventsCenter.once(POWER_UP_COMPLETE_KEY, effortOutcome, this);
         eventsCenter.emit(POWER_UP_COMPLETE_KEY);
@@ -467,8 +518,8 @@ var doChoice = function () {
 var effortOutcome = function() {
     choice = this.registry.get('choice');
     // get number of achieved button presses 
-    pressCount = this.registry.get('pressCount');
-    pressTimes = this.registry.get('pressTimes');  // [?we want this - might make code run slow...]
+    pressCount = this.registry.get('pressCount') ?? 0;
+    pressTimes = this.registry.get('pressTimes') ?? [];  // [?we want this - might make code run slow...]
     
     // if ppt chooses high effort and clears trial effort threshold, fly across sky and collect coins!
     if (choice == 'route 1' && pressCount >= trialEffort1) {
@@ -591,6 +642,46 @@ var effortOutcome = function() {
                             },                         
                             callbackScope: this});
 
+    } else if (choice == 'interruption') {
+        trialSuccess = 0;
+        consecutiveMissedTrials += 1; // reset this value? increment it?
+        powerCountdown = 0;
+        choiceCompleteTime = 0;
+
+        // display interruption message for a couple of seconds
+        this.feedbackMessage = new Message(
+            this,
+            gameWidth,
+            0xFFDBDB,
+            0xFF9696,
+            "Task was interrupted,\nskipping ahead to the next trial.",
+            "#9B0000",
+            80
+        );
+        this.tweens.add({        
+            targets: this.feedbackMessage,
+            scaleX: { start: 0, to: 1 },
+            scaleY: { start: 0, to: 1 },
+            ease: 'Linear',    
+            duration: animationTime * 3, // 1.2 seconds 
+            repeat: 0,      
+            yoyo: false
+        });
+        // then play powerup fail anim and progress via slow route
+        this.time.addEvent({delay: feedbackTime * 3 + 250, 
+                            callback: function() {
+                                this.feedbackMessage.destroy();  // Add this line to destroy the background
+                                // then play short 'powerup fail' anim:
+                                // this.player.sprite.anims.play('powerupfail', true);
+                                // and progress via bridge route (with sad face)
+                                    // player progresses via bridge and earns no extra reward
+                                this.player.sprite.setVelocityX(playerVelocity/5);   // 5,6
+                                this.player.sprite.anims.play('sadrun', true);
+                                this.physics.add.collider(this.player.sprite, this.bridgeEndPoint, 
+                                                            function(){eventsCenter.emit('bumpme');}, null, this); 
+                                eventsCenter.once('bumpme', onejump, this);
+                            },                         
+                            callbackScope: this});
     } else {  // else if fail to reach trial effort threshold
         trialSuccess = 0;
         consecutiveMissedTrials = 0;
@@ -672,7 +763,11 @@ var trialEnd = function () {
     }
     else {
         // iterate trial number
-        trialNo++;     
+        trialNo++;
+
+        // clear any event listners still active so they aren't leaked
+        eventsCenter.removeAllListeners();
+
         // move to next trial
         this.scene.restart();        // [?wrap in delay function to ensure saving works]
     }
@@ -780,6 +875,7 @@ var continueGameAfterBreak = function(context) {
 
     // move to next trial
     context.bottomScreenPanel = null;
+    eventsCenter.removeAllListeners();
     context.scene.restart();
 }
 
@@ -935,7 +1031,7 @@ var saveData = function(context) {
     // update the thresholdMax from the registry
     thresholdMax = context.registry.get('thresholdMax');
 
-    if (choice == 'timeout') {
+    if (choice == 'timeout' || choice == 'interruption') {
         // if the choice was a timeout then reset all the relevant variables so the payload doesn't retain the previous trial's data
         trialEffortPropChosen = 0;
         trialEffort = 0;

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -368,7 +368,6 @@ export default class MainTask extends BaseScene {
         // allow player to move
         this.player.update(); 
 
-        // TODO: Fix random issue where the interruption handler isn't called after an interruption
         let cache = GameCache.cache;
         if (cache && cache.interruptionTimestamp) {
             InteruptionsHandler.handleInteruption(this, cache);

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -377,17 +377,6 @@ export default class MainTask extends BaseScene {
             GameCache.cache.interruptionTimestamp = null; // prevent this from being evaluated in subsequent updates
         }
 
-        // Check for interruption timestamp from the GameCache
-        // Compare with current timestamp
-        // if less than 3 mins
-        // var interruptionTimestamp = GameCache.cache.interruptionTimestamp;
-        // if (interruptionTimestamp && interruptionTimestamp < Date.now() - 5000) {
-        //     // Send message to the app to indicate that the game is complete
-        //     EmbedContext.sendMessage('gameComplete', {});
-        //     // Stop the scene so that all visuals are removed
-        //     this.scene.stop();
-        // }
-        
         ////////////GAME COMPLETE WHEN ALL TRIALS HAVE RUN////////////////
         if (trialNo == maxTrials) {
             // Send message to the app to indicate that the game is complete

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -25,7 +25,7 @@ import { POWER_UP_COMPLETE_KEY } from "../elements/PowerPanel.js";
 import GameCache from "../embedContext/GameCache.js";
 import TaskAttempt from "../embedContext/TaskAttempt.js";
 import { POWER_COUNTDOWN_KEY } from "../elements/CountdownPanel.js";
-import { BREAK_TAG, TIMEOUT_TAG, ARE_YOU_THERE_TAG } from "../elements/BottomScreenPanel.js";
+import { BREAK_TAG, TIMEOUT_TAG, ARE_YOU_THERE_TAG, EXIT_TASK_TAG, GAME_COMPLETE_TAG } from "../elements/BottomScreenPanel.js";
 import InteruptionsHandler from "../embedContext/InteruptionsHandler.js";
 import CloseMessage from "../embedContext/CloseMessage.js";
 
@@ -168,6 +168,8 @@ export default class MainTask extends BaseScene {
         this.missedTrialDialogsShown = this.registry.get('missedTrialDialogsShown') ?? 0;
         this.interruptionShowAreYouThereDialog = false;
         this.interruptionShowTimesUpDialog = false;
+        this.interruptionExitTaskDialog = false;
+        this.interruptionGameCompleteDialog = false;
         this.taskRequiresRestart = false;
         this.interruptionOccured = false;
         this.routeSelectorPanel = null;
@@ -443,6 +445,16 @@ export default class MainTask extends BaseScene {
             // do nothing, player will be walking across the bridge
             console.log('3F-D');
         }
+    }
+
+    switchToTimesUpDialog() {
+        // ensure the are you still there dialog is there
+        if (this.bottomScreenPanel != null && this.bottomScreenPanel.tag != ARE_YOU_THERE_TAG) {
+            return;
+        }
+
+        // show the times up dialog
+        showTimeUpDialog(this);
     }
 }
 
@@ -740,8 +752,20 @@ var trialEnd = function () {
     let isLastTrial = trialNo == nTrials - 1;
     let missedTrialDialogShownLimitReached = (this.missedTrialDialogsShown >= missedTrialDialogLimit) && missedTrialDialogLimit > 0; // ensure that a limit of 0 allows the dialog to be shown as many times as needed
 
+    // should an significant interruption occur after reaching 80% of the trials, show the task complete dialog to inform them the task is done
+    if (this.interruptionGameCompleteDialog == true && !isLastTrial) {
+        stopPlayer(this);
+        showTaskCompleteDialog(this);
+        this.interruptionGameCompleteDialog = false;
+    }
+    // if an interruption occurs and we need to close the task to restart it, show a message beforehand to explain they they need to re-enter the task
+    else if (this.interruptionExitTaskDialog == true && !isLastTrial) {
+        stopPlayer(this);
+        showExitTaskDialog(this);
+        this.interruptionExitTaskDialog = false;
+    }
     // if an interruption occured and we need to show the are you still there dialog, show it
-    if (this.interruptionShowAreYouThereDialog == true && !isLastTrial) {
+    else if (this.interruptionShowAreYouThereDialog == true && !isLastTrial) {
         stopPlayer(this);
         showMissedTrialDialog(this);
         this.interruptionShowAreYouThereDialog = false;
@@ -967,6 +991,39 @@ var showBreakDialog = function(context) {
     );
 }
 
+var showExitTaskDialog = function(context) {
+    let retryTaskText = "You've been away too long, and may need to try again.";
+    let showExitDialog = false;
+    let incrementAttemptCount = false;
+    context.taskRequiresRestart = false;
+
+    showBottomScreenPanel(
+        context,
+        "Retry task",
+        retryTaskText,
+        "EXIT",
+        null,
+        EXIT_TASK_TAG,
+        () => { exitGame(context, showExitDialog, incrementAttemptCount); }, // just exit the task, don't worry about incrementing the attempt count or restarting the game progress
+        () => { exitGame(context, showExitDialog, incrementAttemptCount); }
+    );
+}
+
+var showTaskCompleteDialog = function(context) {
+    let taskCompleteText = "You've reached the minimum required number of completed trials but due to an interruption you cannot progress through the rest of the trials. You will still recieve your bonus payment.";
+
+    showBottomScreenPanel(
+        context,
+        "Task complete!",
+        taskCompleteText,
+        "EXIT",
+        null,
+        GAME_COMPLETE_TAG,
+        () => { gameCompleted(); }, // game is complete, exit the task
+        () => { gameCompleted(); }
+    );
+}
+
 var showBottomScreenPanel = function(context, titleText, subtitleText, bottomButtonText, countdownTimerMS, tag, onContinuePressed, onTimeout) {
     let camera = context.cameras.main;
 
@@ -991,6 +1048,10 @@ var showBottomScreenPanel = function(context, titleText, subtitleText, bottomBut
         repeat: 0,      
         yoyo: false
     });    
+}
+
+var gameCompleted = function() {
+    EmbedContext.sendMessage('gameComplete', {});
 }
 
 var storeCountdownStarted = function(startTime) {

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -827,6 +827,11 @@ var setUpMaxThreshold = function(context) {
     // if we have a stored maxPressCount then use it
     if (GameCache.cache?.maxPressCount) {
         maxPressCount = GameCache.cache.maxPressCount;
+
+        // if the current maxPressCount is less than the minimum presses then enforce the minimum
+        if (maxPressCount < minPressMax) {
+            maxPressCount = minPressMax;
+        }
         context.registry.set('thresholdMax', maxPressCount);
         return;
     }

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -25,6 +25,9 @@ import { POWER_UP_COMPLETE_KEY } from "../elements/PowerPanel.js";
 import GameCache from "../embedContext/GameCache.js";
 import TaskAttempt from "../embedContext/TaskAttempt.js";
 import { POWER_COUNTDOWN_KEY } from "../elements/CountdownPanel.js";
+import { BREAK_TAG, TIMEOUT_TAG, ARE_YOU_THERE_TAG } from "../elements/BottomScreenPanel.js";
+import InteruptionsHandler from "../embedContext/InteruptionsHandler.js";
+import CloseMessage from "../embedContext/CloseMessage.js";
 
 // initialize all the global vars (must be a better way of doing this...)
 var gameHeight; 
@@ -71,9 +74,9 @@ var practiceorReal = 1; // use the main task instruction panels
 var coinsWonThisTrial = 0;
 var smallDeviceOffset = 0;
 var consecutiveMissedTrials = 0;
-var missedTrialDialogsShown = 0;
 var randTrialsIdx;
 var powerCountdown;
+var timeoutInterval; 
 
 // this function extends Phaser.Scene and includes the core logic for the game
 export default class MainTask extends BaseScene {
@@ -162,6 +165,11 @@ export default class MainTask extends BaseScene {
         maxTrials = nTrials;
         trialsPerBlock = nTrials / nBlocks;  // blocks divide trials
         let catchIdx = trials.catchIdx ?? defaultCatchIdx;
+        
+        this.missedTrialDialogsShown = this.registry.get('missedTrialDialogsShown') ?? 0;
+        this.interruptionShowAreYouThereDialog = false;
+        this.interruptionShowTimesUpDialog = false;
+        this.taskRequiresRestart = false;
 
         // setup the game with the cached game state if present
         loadGameFromCache(this);
@@ -236,7 +244,14 @@ export default class MainTask extends BaseScene {
         this.closeButton.setInteractive();
         this.closeButton.on('pointerdown', () => {
             let shouldShowExitDialog = true
-            exitGame(shouldShowExitDialog);
+            let incrementAttemptCount = false;
+
+            // if there user leave the task for any reason after passing the calibration trials, increment the attempt count
+            if (GameCache.cache && GameCache.cache.trialNumber >= nCalibrates) {
+                incrementAttemptCount = true
+            }
+
+            exitGame(this, shouldShowExitDialog, incrementAttemptCount);
         });
 
         //////////////ADD PLAYER SPRITE////////////////////
@@ -352,6 +367,24 @@ export default class MainTask extends BaseScene {
         ///////////SPRITES THAT REQUIRE TIME-STEP UPDATING FOR ANIMATION//////////
         // allow player to move
         this.player.update(); 
+
+        // TODO: Fix random issue where the interruption handler isn't called after an interruption
+        let cache = GameCache.cache;
+        if (cache && cache.interruptionTimestamp) {
+            InteruptionsHandler.handleInteruption(this, cache);
+            GameCache.cache.interruptionTimestamp = null; // prevent this from being evaluated in subsequent updates
+        }
+
+        // Check for interruption timestamp from the GameCache
+        // Compare with current timestamp
+        // if less than 3 mins
+        // var interruptionTimestamp = GameCache.cache.interruptionTimestamp;
+        // if (interruptionTimestamp && interruptionTimestamp < Date.now() - 5000) {
+        //     // Send message to the app to indicate that the game is complete
+        //     EmbedContext.sendMessage('gameComplete', {});
+        //     // Stop the scene so that all visuals are removed
+        //     this.scene.stop();
+        // }
         
         ////////////GAME COMPLETE WHEN ALL TRIALS HAVE RUN////////////////
         if (trialNo == maxTrials) {
@@ -607,10 +640,23 @@ var effortOutcome = function() {
 
 // 4. When player hits end of scene, save trial data and move on to the next trial (reload the scene)
 var trialEnd = function () {
-    // if the user has been shown the 'Are you still there?' message and they trigger it again, kick them out of the task
     let isLastTrial = trialNo == nTrials - 1;
-    let missedTrialDialogShownLimitReached = (missedTrialDialogsShown >= missedTrialDialogLimit) && missedTrialDialogLimit > 0; // ensure that a limit of 0 allows the dialog to be shown as many times as needed
-    if (consecutiveMissedTrials >= missedTrialLimit && !isLastTrial && missedTrialDialogShownLimitReached) {
+    let missedTrialDialogShownLimitReached = (this.missedTrialDialogsShown >= missedTrialDialogLimit) && missedTrialDialogLimit > 0; // ensure that a limit of 0 allows the dialog to be shown as many times as needed
+
+    // if an interruption occured and we need to show the are you still there dialog, show it
+    if (this.interruptionShowAreYouThereDialog == true && !isLastTrial) {
+        stopPlayer(this);
+        showMissedTrialDialog(this);
+        this.interruptionShowAreYouThereDialog = false;
+    }
+    // if an interruption occured and we need to show the times up dialog, show it
+    else if (this.interruptionShowTimesUpDialog == true && !isLastTrial) {
+        stopPlayer(this);
+        showTimeUpDialog(this);
+        this.interruptionShowTimesUpDialog = false;
+    }
+    // if the user has been shown the 'Are you still there?' message and they trigger it again, kick them out of the task
+    else if (consecutiveMissedTrials >= missedTrialLimit && !isLastTrial && missedTrialDialogShownLimitReached) {
         stopPlayer(this);
         showTimeUpDialog(this);
     }
@@ -655,7 +701,7 @@ var loadGameFromCache = function(context) {
     const cache = GameCache.cache;
     if (cache == null) {
         // if no cache to load from, create a new one with the default values
-        GameCache.cache = new GameCache(true, 0, undefined, 0, {}, [], context.trialSequenceFile);
+        GameCache.cache = new GameCache(true, 0, undefined, 0, {}, [], context.trialSequenceFile, null);
         return;
     }
 
@@ -734,11 +780,13 @@ var continueGameAfterBreak = function(context) {
     }
 
     // move to next trial
+    context.bottomScreenPanel = null;
     context.scene.restart();
 }
 
-var exitGame = function(shouldShowExitDialog) {
-    EmbedContext.sendMessage('close', shouldShowExitDialog);
+var exitGame = function(context, shouldShowExitDialog, shouldIncrementAttemptCount) {
+    let closeMessage = new CloseMessage(shouldShowExitDialog, shouldIncrementAttemptCount, context.taskRequiresRestart);
+    EmbedContext.sendMessage('close', closeMessage.stringify());
 }
 
 var stopPlayer = function(context) {
@@ -747,8 +795,11 @@ var stopPlayer = function(context) {
 }
 
 var showMissedTrialDialog = function(context) {
+    let storedMissedTrialDialogsShown = context.registry.get('missedTrialDialogsShown') ?? 0;
+    context.registry.set('missedTrialDialogsShown', storedMissedTrialDialogsShown + 1);
+    context.missedTrialDialogShown += storedMissedTrialDialogsShown + 1;
+
     let missedTrialsDialogText = "Continue within the next 2 minutes to keep collecting coins.";
-    missedTrialDialogsShown += 1;
     consecutiveMissedTrials = 0;
 
     showBottomScreenPanel(
@@ -757,6 +808,7 @@ var showMissedTrialDialog = function(context) {
         missedTrialsDialogText,
         "CONTINUE",
         breakTime,
+        ARE_YOU_THERE_TAG,
         () => { continueGameAfterBreak(context); },
         () => { showTimeUpDialog(context); }
     );
@@ -770,14 +822,27 @@ var showTimeUpDialog = function(context) {
         timeoutMessage = "Unfortunately you've run out of time to continue the this task. Try again to recieve a bonus payment.";
     }
 
+    let showExitDialog = false;
+    let incrementAttemptCount = true;
+
+    // Once we see the timeout message, we have 2 mins to return to the task otherwise we need to restart
+    timeoutInterval = setInterval(
+        () => {
+            context.taskRequiresRestart = true;
+            clearInterval(timeoutInterval);
+        },
+        1000 * 60 * 2 // 2 mins
+    );
+
     showBottomScreenPanel(
         context,
         "Times up!",
         timeoutMessage,
         "EXIT",
         null,
-        () => { exitGame(false); }, // no need to show the exit dialog as we're already showing the time up dialog
-        () => { exitGame(false); } // no need to show the exit dialog as we're already showing the time up dialog
+        TIMEOUT_TAG,
+        () => { exitGame(context, showExitDialog, incrementAttemptCount); },
+        () => { exitGame(context, showExitDialog, incrementAttemptCount); }
     );
 }
 
@@ -789,12 +854,13 @@ var showBreakDialog = function(context) {
         breakTextContent,
         "CONTINUE",
         breakTime,
+        BREAK_TAG,
         () => { continueGameAfterBreak(context); }, // continue the game regardless after the break is automatically or manually stopped
         () => { continueGameAfterBreak(context); }
     );
 }
 
-var showBottomScreenPanel = function(context, titleText, subtitleText, bottomButtonText, countdownTimerMS, onContinuePressed, onTimeout) {
+var showBottomScreenPanel = function(context, titleText, subtitleText, bottomButtonText, countdownTimerMS, tag, onContinuePressed, onTimeout) {
     let camera = context.cameras.main;
 
     context.bottomScreenPanel = new BottomScreenPanel(
@@ -804,6 +870,7 @@ var showBottomScreenPanel = function(context, titleText, subtitleText, bottomBut
         subtitleText,
         bottomButtonText,
         countdownTimerMS,
+        tag,
         onContinuePressed,
         onTimeout
     );

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -900,7 +900,7 @@ var saveData = function(context) {
         // get variables to use 
         pressTimes = context.registry.get('pressTimes') ?? [];
         pressCount = context.registry.get('pressCount') ?? 0;
-        if (pressTimes, pressTimes.length > 0) {
+        if (pressTimes.length > 0) {
             pressStartTime = pressTimes[0]; // pressStartTime is the first pressTime
             pressEndTime = pressTimes[pressTimes.length - 1]; // pressEndTime is the last pressTime
         }

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -63,8 +63,8 @@ var choice;
 var choiceCompleteTime;
 var choiceRT;
 var pressCount;
-var pressStartTime
-var pressEndTime
+var pressStartTime = 0;
+var pressEndTime = 0;
 var pressTimes;
 var trialSuccess;
 var trialEndTime;
@@ -898,10 +898,12 @@ var saveData = function(context) {
     // perform recalibration if required and within the first nCalibrates trials
     if (trialNo < nCalibrates) {
         // get variables to use 
-        pressTimes = context.registry.get('pressTimes');
-        pressCount = context.registry.get('pressCount');
-        pressStartTime = pressTimes[0]; // pressStartTime is the first pressTime
-        pressEndTime = pressTimes[pressTimes.length - 1]; // pressEndTime is the last pressTime
+        pressTimes = context.registry.get('pressTimes') ?? [];
+        pressCount = context.registry.get('pressCount') ?? 0;
+        if (pressTimes, pressTimes.length > 0) {
+            pressStartTime = pressTimes[0]; // pressStartTime is the first pressTime
+            pressEndTime = pressTimes[pressTimes.length - 1]; // pressEndTime is the last pressTime
+        }
 
         // get level of effort chosen
         if (choice == 'route 1') {

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -20,6 +20,8 @@ import PracticeTaskAttempt from "../embedContext/PracticeTaskAttempt.js";
 import { POWER_COUNTDOWN_KEY } from "../elements/CountdownPanel.js";
 import InteruptionsHandler from "../embedContext/InteruptionsHandler.js";
 import CloseMessage from "../embedContext/CloseMessage.js";
+import BottomScreenPanel from "../elements/BottomScreenPanel.js";
+import { EXIT_TASK_TAG } from "../elements/BottomScreenPanel.js"
 
 // initialize some global vars
 var gameHeight;
@@ -135,6 +137,9 @@ export default class PracticeTask extends BaseScene {
         if (window.innerHeight < 800) {
             smallDeviceOffset = -175;
         }
+
+        this.interruptionExitTaskDialog = false;
+        this.bottomScreenPanel = null;
 
         ////////////////////////CREATE WORLD//////////////////////////////////////
         // game world created in Tiled (https://www.mapeditor.org/)
@@ -687,10 +692,19 @@ var pracTrialEnd = function () {
     // savePracTaskData(pracTrial, this.registry.get(`pracTrial${pracTrial}`));    // [for firebase]
     //saveTrialDataPav(this.registry.get(`pracTrial${pracTrial}`));             // [for Pavlovia deployment]
     
-    // iterate trial number
-    pracTrial++; 
-    // move to next trial
-    this.scene.restart();        // [?wrap in delay function to ensure saving works] 
+    let isLastPracticeTrial = pracTrial == nPracTrials - 1;
+    // if we encountered an interruption, show the exit dialog but dont increment atempt count.
+    // theres no need to reset progress since since the game state isn't updated untill we complete all the practice rounds
+    if (this.interruptionExitTaskDialog == true && !isLastPracticeTrial) {
+        stopPlayer(this);
+        showExitTaskDialog(this);
+        this.interruptionExitTaskDialog = false;
+    } else {
+        // iterate trial number
+        pracTrial++; 
+        // move to next trial
+        this.scene.restart();
+    }
 };
 
 
@@ -713,4 +727,55 @@ var onejump = function () {
 
 var storeCountdownStarted = function(startTime) {
     powerCountdown = startTime;
+}
+
+var stopPlayer = function(context) {
+    context.player.sprite.setVelocityX(0);
+    context.player.sprite.anims.play('wait', true);
+}
+
+var showExitTaskDialog = function(context) {
+    let retryTaskText = "The tutorial rounds were interrupted. Please exit and try again.";
+
+    showBottomScreenPanel(
+        context,
+        "Retry task",
+        retryTaskText,
+        "EXIT",
+        null,
+        EXIT_TASK_TAG,
+        () => { exitGame(); }, // just exit the task, don't worry about incrementing the attempt count or restarting the game progress
+        () => { exitGame(); }
+    );
+}
+
+var showBottomScreenPanel = function(context, titleText, subtitleText, bottomButtonText, countdownTimerMS, tag, onContinuePressed, onTimeout) {
+    let camera = context.cameras.main;
+
+    context.bottomScreenPanel = new BottomScreenPanel(
+        context,
+        camera.scrollX + camera.width / 2,
+        titleText,
+        subtitleText,
+        bottomButtonText,
+        countdownTimerMS,
+        tag,
+        onContinuePressed,
+        onTimeout
+    );
+
+    context.tweens.add({        
+        targets: context.bottomScreenPanel,
+        scaleX: { start: 0, to: 1 },
+        scaleY: { start: 0, to: 1 },
+        ease: 'Linear',    
+        duration: pracAnimationTime,
+        repeat: 0,      
+        yoyo: false
+    });    
+}
+
+var exitGame = function() {
+    let closeMessage = new CloseMessage(false, false, false);
+    EmbedContext.sendMessage('close', closeMessage.stringify());
 }

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -18,6 +18,7 @@ import Message from "../elements/message.js";
 import GameCache from "../embedContext/GameCache.js";
 import PracticeTaskAttempt from "../embedContext/PracticeTaskAttempt.js";
 import { POWER_COUNTDOWN_KEY } from "../elements/CountdownPanel.js";
+import CloseMessage from "../embedContext/CloseMessage.js";
 
 // initialize some global vars
 var gameHeight;
@@ -184,8 +185,8 @@ export default class PracticeTask extends BaseScene {
         this.closeButton.setScrollFactor(0);
         this.closeButton.setInteractive();
         this.closeButton.on('pointerdown', () => {
-            let shouldShowExitDialog = false
-            EmbedContext.sendMessage('close', shouldShowExitDialog);
+            let closeMessage = new CloseMessage(false, false, false);
+            EmbedContext.sendMessage('close', closeMessage.stringify());
         });
 
         //////////////ADD PLAYER SPRITE////////////////////
@@ -294,7 +295,7 @@ export default class PracticeTask extends BaseScene {
             }
 
             // signal to the cache that the practice is complete
-            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null, null, calibrationComplete)
+            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null, null, calibrationComplete, null)
             EmbedContext.sendMessage('currentGameCache', cache.stringify());
 
             // progress to the next scene

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -140,6 +140,8 @@ export default class PracticeTask extends BaseScene {
 
         this.interruptionExitTaskDialog = false;
         this.bottomScreenPanel = null;
+        this.powerPanel = null;
+        this.interruptionOccured = false;
 
         ////////////////////////CREATE WORLD//////////////////////////////////////
         // game world created in Tiled (https://www.mapeditor.org/)
@@ -315,6 +317,69 @@ export default class PracticeTask extends BaseScene {
             // progress to the next scene
             this.registry.set('maxPressCount', maxPressCount);
             this.launchNextScene();
+        }
+    }
+
+    showExitDialogAfterInterruption() {
+        // a user was interrupted whilst in the middle of an individual trial, in this scenario we won't allow them to
+        // continue to the next practice trial.
+        // In all scenarios we will show the exit dialog and the user will need to restart from the beginning of the practice task.
+    
+        /*
+            1. If current animation playing is the walking animation before the route selector apears
+            2. If the route selector panel is visible,
+            3. If the power up scene is active
+            4. If the user has already completed the trial and is crossing the bridge, show the dialog once pickle reaches the end of the bridge
+        */
+            let isLastPracticeTrial = pracTrial == nPracTrials - 1;
+
+            if (this.player.sprite.x <= decisionPointX && this.player.sprite.anims.currentAnim.key == 'run' && !isLastPracticeTrial) {
+            console.log('1A-A');
+
+            // no active panel, stop the player and show the dialog
+            stopPlayer(this);
+            showExitTaskDialog(this);
+        } else if (this.instructionsPanel != null && this.player.sprite.body.velocity.x == 0 && this.player.sprite.anims.currentAnim.key == 'wait' && !isLastPracticeTrial) {
+            console.log('1A-B');
+
+            // remove any active feedback message
+            if (feedbackMessage) {
+                clearTimeout(routeSelectionTransitionTimer);
+                feedbackMessage.destroy();
+                feedbackMessage = null;
+            }
+
+            // remove the route selector panel
+            this.instructionsPanel.destroy();
+            this.instructionsPanel = null;
+
+            // show the exit task dialog in its place
+            stopPlayer(this);
+            showExitTaskDialog(this);
+        } else if (this.powerPanel != null && ['powerup', 'wait'].includes(this.player.sprite.anims.currentAnim.key) && !isLastPracticeTrial) {
+            console.log('1A-C');
+
+            // mark that an interruption occured so the feedback message dismiss handler doesn't run
+            this.interruptionOccured = true;
+
+            // remove any active feedback message
+            if (feedbackMessage) {
+                clearTimeout(routeSelectionTransitionTimer);
+                feedbackMessage.destroy();
+                feedbackMessage = null;
+            }
+
+            // remove the power panel
+            this.powerPanel.destroy();
+            this.powerPanel = null;
+            
+            // show the exit task dialog in its place
+            stopPlayer(this);
+            showExitTaskDialog(this);  
+        } else {
+            // do nothing, player will be walking across the bridge, the exit dialog will be shown at the end of the bridge
+            console.log('1A-D');
+            this.interruptionExitTaskDialog = true;
         }
     }
 }
@@ -530,7 +595,9 @@ var effortOutcome = function() {
         // then play powerup fail anim and progress via slow route
         this.time.addEvent({delay: pracFeedbackTime + 250, 
                             callback: function(){
-                                feedbackMessage.destroy();
+                                if (this.interruptionOccured) { return; }
+
+                                feedbackMessage?.destroy();
                                 // then play short 'powerup fail' anim:
                                 this.player.sprite.anims.play('powerupfail', true);
                                 // and progress via bridge route (with sad face)
@@ -587,6 +654,8 @@ var effortOutcome = function() {
             // then player floats across 'high route' and collects coins
             this.time.addEvent({delay: pracFeedbackTime + 250, 
                 callback: function(){
+                    if (this.interruptionOccured) { return; }
+
                     let playerSpeedAdjustment = window.innerHeight < 800 ? 4 : 3; // slow down the player a bit more on the smaller screens so they dont miss the coins
                     feedbackMessage?.destroy();
                     this.player.sprite.anims.play('float', true);    
@@ -601,6 +670,8 @@ var effortOutcome = function() {
             // then player floats across 'low route' and collects coins
             this.time.addEvent({delay: pracFeedbackTime + 250, 
                 callback: function() {
+                    if (this.interruptionOccured) { return; }
+
                     feedbackMessage?.destroy();
                     this.player.sprite.anims.play('float', true);    
                     this.player.sprite.setVelocityX(playerVelocity/3);
@@ -644,7 +715,9 @@ var effortOutcome = function() {
         // then play powerup fail anim and progress via slow route
         this.time.addEvent({delay: pracFeedbackTime + 250, 
                             callback: function(){
-                                feedbackMessage.destroy();
+                                if (this.interruptionOccured) { return; }
+
+                                feedbackMessage?.destroy();
                                 // then play short 'powerup fail' anim:
                                 this.player.sprite.anims.play('powerupfail', true);
                                 // and progress via bridge route (with sad face)
@@ -665,6 +738,20 @@ var effortOutcome = function() {
 
 // 4. When player hits end of scene, save trial data and move on to the next trial (reload the scene)
 var pracTrialEnd = function () {
+    // if the interruption needs to be shown, just show that, no practice trial data will be sent off,
+    // no maxPressCount update, etc. The user will have to return to the start of the practice trials so
+    // they will go through the calibration rounds eventually
+
+    let isLastPracticeTrial = pracTrial == nPracTrials - 1;
+    // if we encountered an interruption, show the exit dialog but dont increment attempt count.
+    // theres no need to reset progress since since the game state isn't updated untill we complete all the practice rounds
+    if (this.interruptionExitTaskDialog == true && !isLastPracticeTrial) {
+        stopPlayer(this);
+        showExitTaskDialog(this);
+        this.interruptionExitTaskDialog = false;
+        return;
+    }
+
     // determine if pressCount exceeded previous practice trials,
     // we don't want to update the max press count if we've completed the calibration
     if (GameCache.cache?.calibrationComplete == true) {
@@ -692,19 +779,14 @@ var pracTrialEnd = function () {
     // savePracTaskData(pracTrial, this.registry.get(`pracTrial${pracTrial}`));    // [for firebase]
     //saveTrialDataPav(this.registry.get(`pracTrial${pracTrial}`));             // [for Pavlovia deployment]
     
-    let isLastPracticeTrial = pracTrial == nPracTrials - 1;
-    // if we encountered an interruption, show the exit dialog but dont increment atempt count.
-    // theres no need to reset progress since since the game state isn't updated untill we complete all the practice rounds
-    if (this.interruptionExitTaskDialog == true && !isLastPracticeTrial) {
-        stopPlayer(this);
-        showExitTaskDialog(this);
-        this.interruptionExitTaskDialog = false;
-    } else {
-        // iterate trial number
-        pracTrial++; 
-        // move to next trial
-        this.scene.restart();
-    }
+    // iterate trial number
+    pracTrial++; 
+
+    // clear any event listners still active so they aren't leaked
+    eventsCenter.removeAllListeners();
+
+    // move to next trial
+    this.scene.restart();
 };
 
 

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -18,6 +18,7 @@ import Message from "../elements/message.js";
 import GameCache from "../embedContext/GameCache.js";
 import PracticeTaskAttempt from "../embedContext/PracticeTaskAttempt.js";
 import { POWER_COUNTDOWN_KEY } from "../elements/CountdownPanel.js";
+import InteruptionsHandler from "../embedContext/InteruptionsHandler.js";
 import CloseMessage from "../embedContext/CloseMessage.js";
 
 // initialize some global vars
@@ -274,6 +275,12 @@ export default class PracticeTask extends BaseScene {
             console.log("practice task passed");
             this.launchNextScene();
             return;
+        }
+
+        let cache = GameCache.cache;
+        if (cache && cache.interruptionTimestamp) {
+            InteruptionsHandler.handleInteruption(this, cache);
+            GameCache.cache.interruptionTimestamp = null; // prevent this from being evaluated in subsequent updates
         }
 
         ///////////SPRITES THAT REQUIRE TIME-STEP UPDATING FOR ANIMATION//////////

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -302,7 +302,9 @@ export default class PracticeTask extends BaseScene {
             }
 
             // signal to the cache that the practice is complete
-            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null, null, calibrationComplete, null)
+            let trialSeqFilename = GameCache.cache?.trialSeqFilename || null;
+            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null, trialSeqFilename, calibrationComplete, null)
+            GameCache.cache = cache;
             EmbedContext.sendMessage('currentGameCache', cache.stringify());
 
             // progress to the next scene

--- a/public/src/scenes/startTaskScene.js
+++ b/public/src/scenes/startTaskScene.js
@@ -1,4 +1,5 @@
 import { BaseScene } from "./baseScene.js";
+import CloseMessage from "../embedContext/CloseMessage.js";
 
 export default class StartTaskScene extends BaseScene {
     constructor() {
@@ -36,8 +37,8 @@ export default class StartTaskScene extends BaseScene {
         this.closeButton.setScrollFactor(0);
         this.closeButton.setInteractive();
         this.closeButton.on('pointerup', () => {
-            let shouldShowExitDialog = false
-            EmbedContext.sendMessage('close', shouldShowExitDialog);
+            let closeMessage = new CloseMessage(false, false, false);
+            EmbedContext.sendMessage('close', closeMessage.stringify());
         });
 
         const container = this.rexUI.add.sizer({


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2652

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Refactored the close messages sent to the app to now tell the app if we need to increment the eefrt attempt count or restart the task from the beginning as well as show the exit dialog
- Implemented the interruption scenario handling from the document given by BDI
- Fixed a bug so now the game progress is saved correctly immediately after completing the practice rounds. You can now return to round 1 instead of from the beginning
- Fixed a bug on the android app where you could resume from a completed game state
- Fixed a crash that occurs when you dont interract with the practice rounds. It now assigns default values to the pressCount and pressTimes registry values
- Added the logic to be able to skip the current round if an interruption occurs. It includes a new message and the duration is approximately 3 times longer than the rest of the messages

## TODOs
<!--- If your PR is still a work-in-progress, add checkboxes to this section to indicate outstanding work to be done. -->
<!--- If not relevant, delete this section. -->
- [x] Update the Android app to support interruptions
- [x] Test, test, test
- [x] If interrupted in a trial, don't allow the user to interact with that trial

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## Notes
- Something to consider: Trial number is incremented immediately after the round is completed so take that in mind when testing edge cases
- While I've handled deliberate app terminations on iOS we need to remember that we are at the mercy of the OS actually sending the notifications, so theres every chance the notification isn't sent and the business logic cannot be executed in that scenario (increment attempt count and restart from beginning if first attempt)
- The PR just adds the interruptions logic for the first 4 scenarios in the document, the last scenario will be implemented in the main Vibe Up 2 apps, the increment attempt count and restart from beginning logic will also be handled in those apps.
- The time logic for the are you there and timeout dialogs do not take into account the time remaining for each of those timers, the interruption logic just assumes the real time you've been away - might be a TODO

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
There are a lot of scenarios to test so make yourself a coffee and probably set aside a good chunk of time to test this out. If you have the game running and the javascript console open you'll be able to see a console log for each interruption scenario and you can use that to verify that particular logic is being run.

For testing if the attempt count is incremented or the task will be restarted, you can check the logs in XCode/Android Studio or place breakpoints on each of those log statements in `EEFRTViewController.swift` and `EEFRTScreen.kt`

Feel free to check off the boxes as you go through and test these:
Scenario 1:
- [x] 1A: Interrupted during the practice rounds -> Restart from practice round 1 with no increment to attempt count

Scenario 2:
- [x] 2A: Interrupted during rounds 1 or 2 for more than 3 mins -> Exit the task but let them continue from where they left off with no increment to attempt count
- [x] 2B: Interrupted during rounds 1 or 2 for less than 3 mins -> Skip the current round

Scenario 3:
- [x] 3A-A: Interrupted between rounds 3-35 and returned while the are you there dialog is active (away less than 2 mins) -> No action, the dialog is active and will continue to count down from where it left off
- [x] 3A-B: Interrupted between rounds 3-35 and returned within 2-4 mins while the are you there dialog is active - Increment attempt count, exit task and let them have another go if first attempt
- [x] 3A-C: Interrupted between round 3-35 and returned after 4 mins while the are you there dialog is active - Increment attempt count, exit task and reset user progress to beginning

- [x] 3B: Interrupted between round 3-35 and returned within 2 mins whilst the times up dialog is active - increment attempt count, exit task and let them have another go if first attempt
- [x] 3C: Interrupted between round 3-35 and returned after 2 mins whilst the times up dialog is active - increment attempt count, exit task and reset user progress to the beginning

- [x] 3D-A: Interrupted between round 3-35 and returned within 3-5 mins (No dialog active before interruption) - Skip the current round and show the are you there dialog when pickle reaches the end of the bridge
- [x] 3D-B: Interrupted between round 3-35 and returned within 3-5 mins (No dialog active before interruption but its been shown before) - Skip the current round and show the timeout dialog at the end after pickle crosses the bridge

- [x] 3E: Interrupted between round 3-35 and returned after 5 mins (no previous dialog active) - show the timeout dialog ay the end of the current round, increment attempt count and restart task

- [x] 3F-A: Interrupted between round 3-35 and returned within 3 mins (no previous dialog active) while pickle is walking to the start of the bridge but before the route selector is shown - skip the current trial and continue from the next trial
- [x] 3F-B: Interrupted between round 3-35 and returned within 3 mins (no previous dialog active) while the route selector panel is active - skip the current trial and continue from the next trial
- [x] 3F-C: Interrupted between round 3-35 and returned within 3 mins (no previous dialog active) while the power up scene is active - Skip the current trial and continue from the next trial
- [x] 3F-D: Interrupted between round 3-35 and returned within 3 mins (no previous dialog active) while pickle is crossing the bridge after the power up scene - Trial is already complete, no action required

Scenario 4:
- [x] 4A: Interrupted after round 35 but returned within 5 mins - Skip the current trial but let the user continue from the next trial
- [x] 4B: Interrupted after round 35 but returned after 5 mins - game is considered complete, exit task

### Other fixes to confirm
- Completing all the practice round and then exiting before the first trial is complete will show the resume trial button on the home screen and allow you to resume from trial 1
- Completing the game on Android will no longer show the resume trial button
- Not interacting with trial 1 no longer causes a crash

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Task interrupted message | Interrupted event log | 
| --- | --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/6d682192-33c6-4d9c-96c3-e43681c9c926" /> | <img width="382" height="578" alt="image" src="https://github.com/user-attachments/assets/506a5497-07ce-44be-8c65-8bb710512006" /> |

