### PR TITLE
Interruptions handling improvements [CON-2685]

### DIFF
--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -35,6 +35,7 @@ export default class InteruptionsHandler {
                 console.log('2A');
                 context.taskRequiresRestart = true;
                 context.interruptionExitTaskDialog = true;
+                context.continueAfterInterruption();
 
                 return;
             } else { // 2B

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -983,7 +983,7 @@ var showBreakDialog = function(context) {
 var showExitTaskDialog = function(context) {
     let retryTaskText = "You've been away too long, and may need to try again.";
     let showExitDialog = false;
-    let incrementAttemptCount = false;
+    let incrementAttemptCount = true;
 
     showBottomScreenPanel(
         context,

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -935,13 +935,13 @@ var showMissedTrialDialog = function(context) {
 }
 
 var showTimeUpDialog = function(context) {
-    var timeoutMessage;
+    // if we are up to at least round 36 then just show the game complete dialog instead
     if (trialNo + 1 >= nTrials * taskRewardsPayoutThreshold) {
-        timeoutMessage = "Unfortunately you've run out of time to continue the this task, but you'll still recieve a bonus payout.";
-    } else {
-        timeoutMessage = "Unfortunately you've run out of time to continue the this task. Try again to recieve a bonus payment.";
+        showTaskCompleteDialog(context);
+        return;
     }
 
+    let timeoutMessage = "Unfortunately you've run out of time to continue the this task. Try again to recieve a bonus payment.";
     let showExitDialog = false;
     let incrementAttemptCount = true;
 

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -656,13 +656,20 @@ var effortOutcome = function() {
         powerCountdown = 0;
         choiceCompleteTime = 0;
 
+        // if the interruption results in the task being exited then we dont want to tell the user that we are skipping to the next trial
+        var messageText = "Task was interrupted"
+        let taskWillExit = this.interruptionExitTaskDialog == true || this.interruptionGameCompleteDialog == true || this.interruptionShowTimesUpDialog == true
+        if (!taskWillExit) {
+            messageText += ",\nskipping ahead to the next trial."
+        }
+
         // display interruption message for a couple of seconds
         this.feedbackMessage = new Message(
             this,
             gameWidth,
             0xFFDBDB,
             0xFF9696,
-            "Task was interrupted,\nskipping ahead to the next trial.",
+            messageText,
             "#9B0000",
             80
         );


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2685

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Don't allow the user to continue the current round if they experience an interruption in rounds 1 or 2
- Show the game complete dialog instead of the times up dialog if we reached round 36
- Increment the attempt count if we get a long interruption (3+ mins) in rounds 1 or 2
- Update the interrupted message to only mention skipping to the next trial if we're not showing a non-continuable dialog

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the following scenarios to confirm the new behaviour works and there are no regressions with the old interruption message:
- 2A now immediately skips the trial, the interrupted message was also updated and the attempt count now also incremented
- Getting the times up dialog from round 36 now gives the game complete dialog
- 2B message is unaffected
- 3D-A message is unaffected
- 3D-B has the new interrupted message
- 3E has the new interrupted message
- 3F message is unaffected
- 4A message is unaffected
- 4B has the new interrupted message

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Updated message |
| --- |
| <img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/458ccbd3-8743-4e89-91e2-95ef0cc15380" /> |