### PR TITLE
Nick/interruption text changes

### DIFF
--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
@@ -1,5 +1,6 @@
 package ai.a2i2.conductor.effrtdemoandroid.persistence
 
+import ai.a2i2.conductor.effrtdemoandroid.util.GameConfigUtils
 import android.content.Context
 import hu.autsoft.krate.SimpleKrate
 import hu.autsoft.krate.booleanPref
@@ -22,6 +23,12 @@ data class GameCache(
     var attemptCount: Int = 1
 ) {
     fun isResumeTrialAvailable(context: Context): Boolean {
+        // Allow the user to resume from the beginning if triggering 2A interruption scenario
+        val gameStorage = GameStorage(context)
+        if (!practiceComplete && !gameStorage.gameMarkedAsComplete && gameStorage.eefrtAttemptCount == GameConfigUtils.MAX_EEFRT_ATTEMPTS) {
+            return true
+        }
+
         return (practiceComplete || trialNumber > 0) && !GameStorage(context).gameMarkedAsComplete
     }
 }

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
@@ -18,7 +18,8 @@ data class GameCache(
     val randTrialsIdx: List<Int>? = null,
     val trialSeqFilename: String? = null,
     var calibrationComplete: Boolean = false,
-    var interruptionTimestamp: Long? = null
+    var interruptionTimestamp: Long? = null,
+    var attemptCount: Int = 1
 ) {
     fun isResumeTrialAvailable(context: Context): Boolean {
         return (practiceComplete || trialNumber > 0) && !GameStorage(context).gameMarkedAsComplete

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -261,6 +261,7 @@ private fun handleMessage(
                     )
                     val currentAttemptCount = GameStorage(context).eefrtAttemptCount
                     viewModel.updateEEFRTAttemptCount(context, currentAttemptCount + 1)
+                    GameStorage(context).cachedGameState?.attemptCount++
                 }
 
                 // ensure the game data is reset if we've actually closed the task, similar scenario to the shouldShowExitDialog

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -6,6 +6,7 @@ import ai.a2i2.conductor.effrtdemoandroid.persistence.PracticeTaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.persistence.TaskAttempt
 import ai.a2i2.conductor.effrtdemoandroid.ui.data.CloseMessage
 import ai.a2i2.conductor.effrtdemoandroid.ui.data.EefrtScreenViewModel
+import ai.a2i2.conductor.effrtdemoandroid.util.GameConfigUtils
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Handler
@@ -271,8 +272,22 @@ private fun handleMessage(
                         TAG,
                         "Task will be restarted on next load"
                     )
-                    viewModel.setCurrentGameState(context, null)
-                    viewModel.resumeTrialAvailable.value = false
+
+                    // Allow the resume button to appear if they trigger the 2A interruption
+                    // Need to check for the trialNumber >=2 since the trial number is already incremented before this check is done
+                    // The '2' value below being compared to the current trial number is generated due to the following:
+                    // 1 (index of trial 2) + 1 (above increment to trial number which occurs before the interruption dialog is shown)
+                    val gameStorage = GameStorage(context)
+                    val cache = gameStorage.cachedGameState
+                    if (cache != null && cache.practiceComplete && cache.trialNumber <= 2) {
+                        viewModel.setCurrentGameState(context, GameCache())
+
+                        // only show the resume button if its within the 2 attempts
+                        viewModel.resumeTrialAvailable.value = gameStorage.eefrtAttemptCount <= GameConfigUtils.MAX_EEFRT_ATTEMPTS
+                    } else {
+                        viewModel.setCurrentGameState(context, null)
+                        viewModel.resumeTrialAvailable.value = false
+                    }
                 }
 
                 if (closeMessage.shouldShowExitDialog) {

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/EefrtScreen.kt
@@ -120,6 +120,7 @@ fun EefrtScreen(
                                 cache.calibrationComplete = true
                                 cache.maxPressCount = gameStorage.calibratedMaxPressCount!!
                             }
+                            cache.attemptCount = gameStorage.eefrtAttemptCount
 
                             val json = Json {
                                 encodeDefaults = true

--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/ui/data/EefrtScreenViewModel.kt
@@ -141,6 +141,7 @@ class EefrtScreenViewModel(
                 )
                 val currentValue = GameStorage(context).eefrtAttemptCount
                 updateEEFRTAttemptCount(context, currentValue + 1)
+                GameStorage(context).cachedGameState?.attemptCount++
             }
 
             if (it.taskRequiresRestart) {

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -259,7 +259,16 @@ extension EEFRTViewController: WKScriptMessageHandler {
                 if !closeMessage.shouldShowExitDialog, closeMessage.taskRequiresRestart {
                     // the task needs to be restarted
                     os_log(.debug, "Task will be restarted on next load")
-                    Defaults.gameCache = nil
+
+                    // Allow the resume button to appear if they trigger the 2A interruption
+                    // Need to check for the trialNumber >=2 since the trial number is already incremented before this check is done
+                    // The '2' value below being compared to the current trial number is generated due to the following:
+                    // 1 (index of trial 2) + 1 (above increment to trial number which occurs before the interruption dialog is shown)
+                    if let cache = Defaults.gameCache, cache.practiceComplete, cache.trialNumber <= 2 {
+                        Defaults.gameCache = GameCache()
+                    } else {
+                        Defaults.gameCache = nil
+                    }
                 }
 
                 if closeMessage.shouldShowExitDialog {

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -145,6 +145,7 @@ class EEFRTViewController: UIViewController {
             cache.calibrationComplete = calibrationComplete
             cache.maxPressCount = calibratedMaxPressCount
         }
+        cache.attemptCount = Defaults.eefrtAttemptCount
 
         if let stringifiedGameCache = try? cache.stringify() {
             let gameCacheJsString = "window.setupGameWithCache(\(stringifiedGameCache));"

--- a/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/EEFRTViewController.swift
@@ -204,6 +204,7 @@ class EEFRTViewController: UIViewController {
                     // increment attempt count in the main app
                     os_log(.debug, "Incremented attempt count")
                     Defaults.eefrtAttemptCount += 1
+                    Defaults.gameCache?.attemptCount += 1
                 }
 
                 if closeMessage.taskRequiresRestart {
@@ -250,6 +251,7 @@ extension EEFRTViewController: WKScriptMessageHandler {
                     // increment attempt count - in main app
                     os_log(.debug, "Incremented attempt count")
                     Defaults.eefrtAttemptCount += 1
+                    Defaults.gameCache?.attemptCount += 1
                 }
 
                 // ensure the game data is reset if we've actually closed the task, similar scenario to the shouldShowExitDialog

--- a/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
@@ -11,6 +11,7 @@ struct GameCache: Codable, DefaultsSerializable {
     var trialSeqFilename: String?
     var calibrationComplete: Bool
     var interruptionTimestamp: Int64?
+    var attemptCount: Int
 
     // Default initializer with default values
     init(
@@ -22,7 +23,8 @@ struct GameCache: Codable, DefaultsSerializable {
         randTrialsIdx: [Int]? = nil,
         trialSeqFilename: String? = nil,
         calibrationComplete: Bool = false,
-        interuptionTimestamp: Int64? = nil
+        interuptionTimestamp: Int64? = nil,
+        attemptCount: Int = 1
     ) {
         self.practiceComplete = practiceComplete
         self.trialNumber = trialNumber
@@ -33,6 +35,7 @@ struct GameCache: Codable, DefaultsSerializable {
         self.trialSeqFilename = trialSeqFilename
         self.calibrationComplete = calibrationComplete
         self.interruptionTimestamp = interuptionTimestamp
+        self.attemptCount = attemptCount
     }
 
     // Decoder initializer
@@ -47,6 +50,7 @@ struct GameCache: Codable, DefaultsSerializable {
         self.trialSeqFilename = try container.decodeIfPresent(String.self, forKey: .trialSeqFilename)
         self.calibrationComplete = try container.decode(Bool.self, forKey: .calibrationComplete)
         self.interruptionTimestamp = try container.decodeIfPresent(Int64.self, forKey: .interruptionTimestamp)
+        self.attemptCount = try container.decode(Int.self, forKey: .attemptCount)
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -60,6 +64,7 @@ struct GameCache: Codable, DefaultsSerializable {
         try container.encodeIfPresent(trialSeqFilename, forKey: .trialSeqFilename)
         try container.encodeIfPresent(calibrationComplete, forKey: .calibrationComplete)
         try container.encodeIfPresent(interruptionTimestamp, forKey: .interruptionTimestamp)
+        try container.encode(attemptCount, forKey: .attemptCount)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -72,6 +77,7 @@ struct GameCache: Codable, DefaultsSerializable {
         case trialSeqFilename
         case calibrationComplete
         case interruptionTimestamp
+        case attemptCount
     }
 
     func stringify() throws -> String {
@@ -79,7 +85,7 @@ struct GameCache: Codable, DefaultsSerializable {
         let data = try encoder.encode(self)
         return String(decoding: data, as: UTF8.self)
     }
-    
+
     func isResumeTrialAvailable() -> Bool {
         (practiceComplete || trialNumber > 0) && !Defaults.gameMarkedAsComplete
     }

--- a/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
@@ -87,6 +87,11 @@ struct GameCache: Codable, DefaultsSerializable {
     }
 
     func isResumeTrialAvailable() -> Bool {
-        (practiceComplete || trialNumber > 0) && !Defaults.gameMarkedAsComplete
+        // Allow the user to resume from the beginning if triggering 2A interruption scenario
+        if practiceComplete == false, !Defaults.gameMarkedAsComplete, Defaults.eefrtAttemptCount == GameConfigUtils.maxEefrtAttempts {
+            return true
+        }
+
+        return (practiceComplete || trialNumber > 0) && !Defaults.gameMarkedAsComplete
     }
 }

--- a/public/src/elements/BottomScreenPanel.js
+++ b/public/src/elements/BottomScreenPanel.js
@@ -7,6 +7,7 @@ export const TIMEOUT_TAG = 'bottomScreenTimeout';
 export const ARE_YOU_THERE_TAG = 'bottomScreenAreYouThere';
 export const EXIT_TASK_TAG = 'bottomScreenExitTask';
 export const GAME_COMPLETE_TAG = 'bottomScreenGameComplete';
+export const TASK_INTERRUPTED_TAG = 'bottomScreenTaskInterrupted';
 
 export default class BottomScreenPanel {
     constructor(scene, x, titleString, subtitleString, bottomButtonString, breakTimeMS, tag, onContinuePressed = () => {}, onTimeout = () => {}) {

--- a/public/src/embedContext/GameCache.js
+++ b/public/src/embedContext/GameCache.js
@@ -1,7 +1,7 @@
 export default class GameCache {
     static cache = null;
 
-    constructor(practiceComplete, trialNumber, maxPressCount, coinRunningTotal, trialResults, randTrialsIdx, trialSeqFilename, calibrationComplete, interruptionTimestamp) {
+    constructor(practiceComplete, trialNumber, maxPressCount, coinRunningTotal, trialResults, randTrialsIdx, trialSeqFilename, calibrationComplete, interruptionTimestamp, attemptCount) {
         this.practiceComplete = practiceComplete;
         this.trialNumber = trialNumber;
         this.maxPressCount = maxPressCount;
@@ -11,6 +11,7 @@ export default class GameCache {
         this.trialSeqFilename = trialSeqFilename;
         this.calibrationComplete = calibrationComplete;
         this.interruptionTimestamp = interruptionTimestamp;
+        this.attemptCount = attemptCount;
     }
 
     stringify() {

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -822,7 +822,7 @@ var loadGameFromCache = function(context) {
     const cache = GameCache.cache;
     if (cache == null) {
         // if no cache to load from, create a new one with the default values
-        GameCache.cache = new GameCache(true, 0, undefined, 0, {}, [], context.trialSequenceFile, null);
+        GameCache.cache = new GameCache(true, 0, undefined, 0, {}, [], context.trialSequenceFile, false, null, 1);
         return;
     }
 
@@ -1157,9 +1157,10 @@ var saveData = function(context) {
 
     // if the user has reached at least 80% then we can mark the calibration as completed
     var calibrationComplete = GameCache.cache?.calibrationComplete == true || trialNo + 1 >= nTrials * taskRewardsPayoutThreshold;
+    let eefrtAttemptCount = GameCache.cache?.attemptCount ?? 1;
 
     // notify the native apps of what the current game state is so they can cache it
-    let currentGameState = new GameCache(true, trialNo + 1, thresholdMax, nCoins, coinChoices, randTrialsIdx, context.trialSequenceFile, calibrationComplete);
+    let currentGameState = new GameCache(true, trialNo + 1, thresholdMax, nCoins, coinChoices, randTrialsIdx, context.trialSequenceFile, calibrationComplete, null, eefrtAttemptCount);
     GameCache.cache = currentGameState;
     EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
 }

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -25,7 +25,7 @@ import { POWER_UP_COMPLETE_KEY } from "../elements/PowerPanel.js";
 import GameCache from "../embedContext/GameCache.js";
 import TaskAttempt from "../embedContext/TaskAttempt.js";
 import { POWER_COUNTDOWN_KEY } from "../elements/CountdownPanel.js";
-import { BREAK_TAG, TIMEOUT_TAG, ARE_YOU_THERE_TAG, EXIT_TASK_TAG, GAME_COMPLETE_TAG } from "../elements/BottomScreenPanel.js";
+import { BREAK_TAG, TIMEOUT_TAG, ARE_YOU_THERE_TAG, EXIT_TASK_TAG, GAME_COMPLETE_TAG, TASK_INTERRUPTED_TAG } from "../elements/BottomScreenPanel.js";
 import InteruptionsHandler from "../embedContext/InteruptionsHandler.js";
 import CloseMessage from "../embedContext/CloseMessage.js";
 
@@ -763,7 +763,7 @@ var trialEnd = function () {
     // if an interruption occured and we need to show the are you still there dialog, show it
     else if (this.interruptionShowAreYouThereDialog == true && !isLastTrial) {
         stopPlayer(this);
-        showMissedTrialDialog(this);
+        showTaskInterruptedDialog(this);
         this.interruptionShowAreYouThereDialog = false;
     }
     // if an interruption occured and we need to show the times up dialog, show it
@@ -1016,6 +1016,26 @@ var showTaskCompleteDialog = function(context) {
         GAME_COMPLETE_TAG,
         () => { gameCompleted(); }, // game is complete, exit the task
         () => { gameCompleted(); }
+    );
+}
+
+var showTaskInterruptedDialog = function(context) {
+    // check to see if this is the first attempt and show a different message explaining that they cannot return if its the 2nd attempt
+    let cache = GameCache.cache;
+    var taskInterruptedText = "Ready to continue? Keep going in the next 2 mins to keep collecting coins";
+    if (cache != null && cache.attemptCount > 1) {
+        taskInterruptedText = "Ready to continue? Keep going in the next 2 mins or else you wont be able to return to the task and collect more coins.";
+    }
+
+    showBottomScreenPanel(
+        context,
+        "Task interrupted",
+        taskInterruptedText,
+        "CONTINUE",
+        breakTime,
+        TASK_INTERRUPTED_TAG,
+        () => { continueGameAfterBreak(context); },
+        () => { showTimeUpDialog(context); }
     );
 }
 

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -988,13 +988,16 @@ var showBreakDialog = function(context) {
 }
 
 var showExitTaskDialog = function(context) {
-    let retryTaskText = "You've been away too long, and may need to try again.";
+    let isSecondAttempt = GameCache.cache?.attemptCount == 2;
+    let retryTaskText = isSecondAttempt ? "You've been away too long, unfortunately you wont be able to earn any more coins." : "You've been away too long, try again to earn more coins to increase your reward."
+    let titleText = isSecondAttempt ? "Exit Task" : "Retry Task"
+    
     let showExitDialog = false;
     let incrementAttemptCount = true;
 
     showBottomScreenPanel(
         context,
-        "Retry task",
+        titleText,
         retryTaskText,
         "EXIT",
         null,

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -310,7 +310,8 @@ export default class PracticeTask extends BaseScene {
 
             // signal to the cache that the practice is complete
             let trialSeqFilename = GameCache.cache?.trialSeqFilename || null;
-            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null, trialSeqFilename, calibrationComplete, null)
+            let eefrtAttemptCount = GameCache.cache?.attemptCount ?? 1;
+            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null, trialSeqFilename, calibrationComplete, null, eefrtAttemptCount)
             GameCache.cache = cache;
             EmbedContext.sendMessage('currentGameCache', cache.stringify());
 

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -332,9 +332,10 @@ export default class PracticeTask extends BaseScene {
             3. If the power up scene is active
             4. If the user has already completed the trial and is crossing the bridge, show the dialog once pickle reaches the end of the bridge
         */
-            let isLastPracticeTrial = pracTrial == nPracTrials - 1;
+        let isLastPracticeTrial = pracTrial == nPracTrials - 1;
+        let routeOrPowerAnimationKeys = ['powerup', 'wait'];
 
-            if (this.player.sprite.x <= decisionPointX && this.player.sprite.anims.currentAnim.key == 'run' && !isLastPracticeTrial) {
+        if (this.player.sprite.x <= decisionPointX && this.player.sprite.anims.currentAnim.key == 'run' && !isLastPracticeTrial) {
             console.log('1A-A');
 
             // no active panel, stop the player and show the dialog
@@ -357,7 +358,7 @@ export default class PracticeTask extends BaseScene {
             // show the exit task dialog in its place
             stopPlayer(this);
             showExitTaskDialog(this);
-        } else if (this.powerPanel != null && ['powerup', 'wait'].includes(this.player.sprite.anims.currentAnim.key) && !isLastPracticeTrial) {
+        } else if (this.powerPanel != null && routeOrPowerAnimationKeys.includes(this.player.sprite.anims.currentAnim.key) && !isLastPracticeTrial) {
             console.log('1A-C');
 
             // mark that an interruption occured so the feedback message dismiss handler doesn't run

--- a/public/src/scenes/startTaskScene.js
+++ b/public/src/scenes/startTaskScene.js
@@ -1,5 +1,6 @@
 import { BaseScene } from "./baseScene.js";
 import CloseMessage from "../embedContext/CloseMessage.js";
+import GameCache from "../embedContext/GameCache.js";
 
 export default class StartTaskScene extends BaseScene {
     constructor() {
@@ -50,8 +51,15 @@ export default class StartTaskScene extends BaseScene {
             space: { top: 35, bottom: 35, item: 20 }
         });
 
+        var titleText = "Let's get started!";
+        var subtitleText = "Nice work! You are now ready to start the main part of the game.\n\nFrom now on, every coin you collect matters – good luck!";
+        if (GameCache.cache != null && GameCache.cache.attemptCount > 1) {
+            titleText = "Let's continue!"
+            subtitleText = "Welcome back! You can continue where you left off, but any further interruptions may invalidate your opportunity to win any coins.";
+        }
+
         // Title
-        const title = this.add.text(0, 0, "Let’s get started!", {
+        const title = this.add.text(0, 0, titleText, {
             fontSize: '18px',
             fontFamily: 'DMSans',
             color: '#000'
@@ -74,16 +82,13 @@ export default class StartTaskScene extends BaseScene {
             .setDisplaySize(displayWidth, displayHeight);
 
         // Description
-        const descText = this.add.text(0, 0,
-            "Nice work! You are now ready to start the main part of the game.\n\nFrom now on, every coin you collect matters – good luck!",
-            {
-                fontSize: '16px',
-                fontFamily: 'DMSans',
-                color: '#404040',
-                lineSpacing: 4,
-                wordWrap: { width: maxWidth }
-            }
-        );
+        const descText = this.add.text(0, 0, subtitleText, {
+            fontSize: '16px',
+            fontFamily: 'DMSans',
+            color: '#404040',
+            lineSpacing: 4,
+            wordWrap: { width: maxWidth }
+        });
 
         // Get Started Button
         const buttonBackground = this.rexUI.add.roundRectangle(0, 0, 0, 0, 30, 0xFFFFFF);


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2665

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Added the attempt count as part of the `GameCache`
- Update the `StartTaskScene` wording based of if its the first attempt or second of the task
- Instead of showing the are you there dialog when interrupted we show a new task interrupted dialog
- The apps now allow you to resume if you trigger 2A interruption scenario
- Updated the exit task dialog shown in scenario 2A based on the current attempt number

## TODOs
<!--- If your PR is still a work-in-progress, add checkboxes to this section to indicate outstanding work to be done. -->
<!--- If not relevant, delete this section. -->
- [ ] Get confirmation if we are happy with the task interrupted dialog changes

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TBD

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Exit task dialog (1st attempt) | Exit task dialog (2nd attempt) | Start task scene (1st attempt) | start task scene (2nd attempt) | Interrupted dialog (1st attempt) | Interrupted dialog (2nd attempt) | 
| --- | --- | --- | --- | --- | --- |
| <img width="361" height="778" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/0ee12d76-6f19-414b-b158-89ecbd06e1bb" /> | <img width="357" height="775" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/6ff5eabb-779c-4b66-a6f8-745e400e5595" /> | <img width="408" height="864" alt="image" src="https://github.com/user-attachments/assets/f386797c-e196-4309-bd46-80b2b30c3d85" /> | <img width="410" height="861" alt="image" src="https://github.com/user-attachments/assets/fe0cc98b-3923-4b00-a524-563cd30c8563" /> | <img width="407" height="869" alt="image" src="https://github.com/user-attachments/assets/861cc9bb-aad1-4f33-85bb-f2f1ed938216" /> | <img width="408" height="866" alt="image" src="https://github.com/user-attachments/assets/2d1a2dda-9aee-4327-892a-5b6d85c1b445" /> |




