### PR TITLE
 Store the individual trial selections in the GameCache [CON-2755]

### DIFF
--- a/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
+++ b/EEFRT Demo Android/app/src/main/java/ai/a2i2/conductor/effrtdemoandroid/persistence/GameStorage.kt
@@ -20,7 +20,8 @@ data class GameCache(
     val trialSeqFilename: String? = null,
     var calibrationComplete: Boolean = false,
     var interruptionTimestamp: Long? = null,
-    var attemptCount: Int = 1
+    var attemptCount: Int = 1,
+    var trialSelections: Map<String, String> = emptyMap()
 ) {
     fun isResumeTrialAvailable(context: Context): Boolean {
         // Allow the user to resume from the beginning if triggering 2A interruption scenario

--- a/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
+++ b/EEFRT Demo iOS/EEFRT Demo/Models/GameCache.swift
@@ -12,6 +12,7 @@ struct GameCache: Codable, DefaultsSerializable {
     var calibrationComplete: Bool
     var interruptionTimestamp: Int64?
     var attemptCount: Int
+    var trialSelections: [String: String]
 
     // Default initializer with default values
     init(
@@ -24,7 +25,8 @@ struct GameCache: Codable, DefaultsSerializable {
         trialSeqFilename: String? = nil,
         calibrationComplete: Bool = false,
         interuptionTimestamp: Int64? = nil,
-        attemptCount: Int = 1
+        attemptCount: Int = 1,
+        trialSelections: [String: String] = [:]
     ) {
         self.practiceComplete = practiceComplete
         self.trialNumber = trialNumber
@@ -36,6 +38,7 @@ struct GameCache: Codable, DefaultsSerializable {
         self.calibrationComplete = calibrationComplete
         self.interruptionTimestamp = interuptionTimestamp
         self.attemptCount = attemptCount
+        self.trialSelections = trialSelections
     }
 
     // Decoder initializer
@@ -51,6 +54,7 @@ struct GameCache: Codable, DefaultsSerializable {
         self.calibrationComplete = try container.decode(Bool.self, forKey: .calibrationComplete)
         self.interruptionTimestamp = try container.decodeIfPresent(Int64.self, forKey: .interruptionTimestamp)
         self.attemptCount = try container.decode(Int.self, forKey: .attemptCount)
+        self.trialSelections = try container.decode([String: String].self, forKey: .trialSelections)
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -65,6 +69,7 @@ struct GameCache: Codable, DefaultsSerializable {
         try container.encodeIfPresent(calibrationComplete, forKey: .calibrationComplete)
         try container.encodeIfPresent(interruptionTimestamp, forKey: .interruptionTimestamp)
         try container.encode(attemptCount, forKey: .attemptCount)
+        try container.encode(trialSelections, forKey: .trialSelections)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -78,6 +83,7 @@ struct GameCache: Codable, DefaultsSerializable {
         case calibrationComplete
         case interruptionTimestamp
         case attemptCount
+        case trialSelections
     }
 
     func stringify() throws -> String {

--- a/public/src/embedContext/GameCache.js
+++ b/public/src/embedContext/GameCache.js
@@ -1,7 +1,7 @@
 export default class GameCache {
     static cache = null;
 
-    constructor(practiceComplete, trialNumber, maxPressCount, coinRunningTotal, trialResults, randTrialsIdx, trialSeqFilename, calibrationComplete, interruptionTimestamp, attemptCount) {
+    constructor(practiceComplete, trialNumber, maxPressCount, coinRunningTotal, trialResults, randTrialsIdx, trialSeqFilename, calibrationComplete, interruptionTimestamp, attemptCount, trialSelections) {
         this.practiceComplete = practiceComplete;
         this.trialNumber = trialNumber;
         this.maxPressCount = maxPressCount;
@@ -12,6 +12,7 @@ export default class GameCache {
         this.calibrationComplete = calibrationComplete;
         this.interruptionTimestamp = interruptionTimestamp;
         this.attemptCount = attemptCount;
+        this.trialSelections = trialSelections;
     }
 
     stringify() {

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -822,7 +822,7 @@ var loadGameFromCache = function(context) {
     const cache = GameCache.cache;
     if (cache == null) {
         // if no cache to load from, create a new one with the default values
-        GameCache.cache = new GameCache(true, 0, undefined, 0, {}, [], context.trialSequenceFile, false, null, 1);
+        GameCache.cache = new GameCache(true, 0, undefined, 0, {}, [], context.trialSequenceFile, false, null, 1, {});
         return;
     }
 
@@ -1178,12 +1178,16 @@ var saveData = function(context) {
     let coinChoices = GameCache.cache?.trialResults ?? {};
     coinChoices['trial' + trialNo] = trialSuccess ? coinsWonThisTrial : 0;
 
+    // save the previous trial seclections to the cache
+    let trialSelections = GameCache.cache?.trialSelections ?? {};
+    trialSelections['trial' + trialNo] = choice;
+
     // if the user has reached at least 80% then we can mark the calibration as completed
     var calibrationComplete = GameCache.cache?.calibrationComplete == true || trialNo + 1 >= nTrials * taskRewardsPayoutThreshold;
     let eefrtAttemptCount = GameCache.cache?.attemptCount ?? 1;
 
     // notify the native apps of what the current game state is so they can cache it
-    let currentGameState = new GameCache(true, trialNo + 1, thresholdMax, nCoins, coinChoices, randTrialsIdx, context.trialSequenceFile, calibrationComplete, null, eefrtAttemptCount);
+    let currentGameState = new GameCache(true, trialNo + 1, thresholdMax, nCoins, coinChoices, randTrialsIdx, context.trialSequenceFile, calibrationComplete, null, eefrtAttemptCount, trialSelections);
     GameCache.cache = currentGameState;
     EmbedContext.sendMessage('currentGameCache', currentGameState.stringify());
 }

--- a/public/src/scenes/practiceTask.js
+++ b/public/src/scenes/practiceTask.js
@@ -316,7 +316,7 @@ export default class PracticeTask extends BaseScene {
             // signal to the cache that the practice is complete
             let trialSeqFilename = GameCache.cache?.trialSeqFilename || null;
             let eefrtAttemptCount = GameCache.cache?.attemptCount ?? 1;
-            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null, trialSeqFilename, calibrationComplete, null, eefrtAttemptCount)
+            let cache = new GameCache(true, 0, maxPressCount, 0, {}, null, trialSeqFilename, calibrationComplete, null, eefrtAttemptCount, {})
             GameCache.cache = cache;
             EmbedContext.sendMessage('currentGameCache', cache.stringify());
 


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2755

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- Updated the GameCache to now store the full trial selections for reach trial

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On both platforms:
Place a break point in the following files to verify the new `trialSelections` is being saved correctly
`EEFRTViewController.swift` Line 325
`EEFRTScreen.kt` Line 325

1) Load Up the app on debugging mode
2) Start a new eefrt task and complete the tutorial
3) Complete a few rounds of the task, making sure to select each route at least once, timeout at least once and encounter an interruption at least once
4) When the breakpoints are hit you can view the new values being stored in the `trialSelections` object
5) Exit the task and re-enter the task to do your second attempt
6) When you complete the next round, the previous trial selection history should be retained.

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
| Android | iOS |
| --- | --- | 
| <img width="398" height="320" alt="image" src="https://github.com/user-attachments/assets/fd2c7bb0-f22b-4fd9-b80e-3e19de6ed629" /> | <img width="250" height="237" alt="image" src="https://github.com/user-attachments/assets/029112f3-c742-4fd4-906d-a3cbad9a70fc" /> |

