### PR TITLE
Handle interruption scenarios where the break dialog is active

### DIFF
--- a/public/src/elements/BottomScreenPanel.js
+++ b/public/src/elements/BottomScreenPanel.js
@@ -123,5 +123,6 @@ export default class BottomScreenPanel {
         this.panelBg?.destroy();
         this.container?.destroy();
         this.underlay?.destroy();
+        eventsCenter.removeAllListeners();
     }
 }

--- a/public/src/embedContext/InteruptionsHandler.js
+++ b/public/src/embedContext/InteruptionsHandler.js
@@ -1,4 +1,4 @@
-import { ARE_YOU_THERE_TAG, TIMEOUT_TAG } from "../elements/BottomScreenPanel";
+import { ARE_YOU_THERE_TAG, TIMEOUT_TAG, BREAK_TAG } from "../elements/BottomScreenPanel";
 import { taskRewardsPayoutThreshold, missedTrialDialogLimit } from "../versionInfo";
 
 export default class InteruptionsHandler {
@@ -53,6 +53,8 @@ export default class InteruptionsHandler {
             3D: User is gone for 3-5 mins and there is no active dialog - show the are you still there dialog (or the times up dialog if shown before)
             3E: User is gone for over 5 mins and theres no active dialog - Show the Times up dialog and restart the task from the beginning (if first attempt) or submit as complete if not.
             3F: User is gone for less than 3 mins and theres no active dialog - dont let the user interract with the current trial and skip ahead to the next trial.
+            3G: User is gone for less than 2 mins while the break dialog is active - no action, the timer will continue to tick down from where it left off.
+            3H: User is gone for more than 2 mins while the break dialog is active - switch to the times up dialog.
         */
         if (cache.trialNumber >= 2 && cache.trialNumber < completionThresholdTrialNo) {
             // 3A
@@ -124,6 +126,19 @@ export default class InteruptionsHandler {
             // 3F
             if (!context.bottomScreenPanel && interuptionLengthMs < threeMinsMs) {
                 context.continueAfterInterruption();
+                return;
+            }
+
+            // 3G
+            if (context.bottomScreenPanel && context.bottomScreenPanel.tag == BREAK_TAG && interuptionLengthMs < twoMinsMs) {
+                console.log('3G');
+                return;
+            }
+
+            // 3H
+            if (context.bottomScreenPanel && context.bottomScreenPanel.tag == BREAK_TAG && interuptionLengthMs >= twoMinsMs) {
+                console.log('3H');
+                context.switchToTimesUpDialog();
                 return;
             }
         }

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -442,6 +442,10 @@ export default class MainTask extends BaseScene {
             return;
         }
 
+        // remove the existing panel first, ensuring no accidental timeout handlers fire
+        this.bottomScreenPanel.destroy();
+        this.bottomScreenPanel = null;
+
         // show the times up dialog
         showTimeUpDialog(this);
     }
@@ -983,7 +987,7 @@ var showBreakDialog = function(context) {
         breakTime,
         BREAK_TAG,
         () => { continueGameAfterBreak(context); }, // continue the game regardless after the break is automatically or manually stopped
-        () => { continueGameAfterBreak(context); }
+        () => {}
     );
 }
 

--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -437,8 +437,8 @@ export default class MainTask extends BaseScene {
     }
 
     switchToTimesUpDialog() {
-        // ensure the are you still there dialog is there
-        if (this.bottomScreenPanel != null && this.bottomScreenPanel.tag != ARE_YOU_THERE_TAG) {
+        // ensure the currenty presented bottom screen panel is either the 'Are you there' or 'Break' dialog.
+        if (this.bottomScreenPanel != null && (this.bottomScreenPanel.tag != ARE_YOU_THERE_TAG && this.bottomScreenPanel.tag != BREAK_TAG)) {
             return;
         }
 


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2798

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
We now handle the following scenarios when interruptions occur when the break dialogs are active:
3G: User is gone for less than 2 mins while the break dialog is active - no action, the timer will continue to tick down from where it left off.
3H: User is gone for more than 2 mins while the break dialog is active - switch to the times up dialog. - user can still 

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Setup:
Updated with `EEFRTViewController line 149` or `EEFRTScreen line 125` with the following changes
```
cache.practiceComplete = true
cache.trialNumber = 9
```
1) Build and run the app
2) Start a new eefrt task, you'll begin from main trial 10
3) When you reach the break dialog background the app, wait a few seconds and foreground the app. The break dialog will still be active
4) Background the app again, after 2 mins have passed then return to the app, the times up dialog will have appeared
5) Wait another 2 mins while the times dialog is active, ensure the dialog is still present on the screen

## Screenshots or example output
<!--- If you made any visual changes, include screenshot(s) here. -->
<!--- If there is output (e.g. JSON from an endpoint) under review, include an example here. -->
<!--- If not relevant, delete this section. -->
<img width="1387" height="860" alt="image" src="https://github.com/user-attachments/assets/7878c1c2-fd7a-455d-a6ec-de67258b52f9" />
