### PR TITLE
Add the break timeout functionality back in [CON-2994]

### DIFF
--- a/public/src/scenes/mainTask.js
+++ b/public/src/scenes/mainTask.js
@@ -985,7 +985,7 @@ var showBreakDialog = function(context) {
         breakTime,
         BREAK_TAG,
         () => { continueGameAfterBreak(context); }, // continue the game regardless after the break is automatically or manually stopped
-        () => {}
+        () => { continueGameAfterBreak(context); }
     );
 }
 


### PR DESCRIPTION
## Why did I make these changes?
<!--- Link to the issue -->
<!--- e.g. https://a2i2.atlassian.net/browse/MUSE-100 -->
<!--- If you do not have a ticket, create one (with a description of the -->
<!--- motivation for your changes). -->
https://deakinuniversity.atlassian.net/browse/CON-2994

## What are the changes?
<!--- Describe what you did, and how the repo contents have changed. -->
<!--- Include anything that is relevant for the reviewer to consider, -->
<!--- e.g. changes that may have caveats/negative consequences, -->
<!--- or things like may have been knowingly left out of the scope of the PR. -->
- A previous commit removed the break dialog's timeout functionality, this PR adds it back in

## Checklist
<!--- Placing an [x] in the [ ] will mark it as done. -->
<!--- *** Make sure you can [x] all these boxes to mark them as ticked. *** -->
- [x] Existing, relevant documentation (eg. README.md) has been updated to reflect my changes <!--- Tick if there is no such documentation -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1) Run the app on either iOS or Android and start a new task (or resume an in-progress one)
2) Progress through the practice trials to get the main trials and progress through those until you get to the first break
3) Once you are at the first break, wait 2 minutes, you will automatically continue to the next trial in the next block
4) Progress through the rest of the current block untill you get to the 2nd break
5) Background the app for 2+ minutes, when you return, the times up dialog will appear (Ensuring that the original interruption scenario 3H still works)